### PR TITLE
FileWatcher, tests, and cleanup

### DIFF
--- a/critic
+++ b/critic
@@ -59,6 +59,7 @@ lib/Tachikoma/Nodes/FileController.pm
 lib/Tachikoma/Nodes/FileHandle.pm
 lib/Tachikoma/Nodes/FileReceiver.pm
 lib/Tachikoma/Nodes/FileSender.pm
+lib/Tachikoma/Nodes/FileWatcher.pm
 lib/Tachikoma/Nodes/Function.pm
 lib/Tachikoma/Nodes/Gate.pm
 lib/Tachikoma/Nodes/Grep.pm

--- a/etc/scripts/workstation/config.pl
+++ b/etc/scripts/workstation/config.pl
@@ -151,8 +151,8 @@ command hosts connect_inet localhost:<tachikoma.tables.port>    tables:service
 command jobs  run_job Shell <services>/engines.tsl
 command hosts connect_inet localhost:<tachikoma.engines.port>   engines:service
 
-command jobs  run_job Shell <services>/hunter.tsl
-command hosts connect_inet localhost:<tachikoma.hunter.port>    hunter:service
+command jobs  run_job Shell <services>/lookup.tsl
+command hosts connect_inet localhost:<tachikoma.lookup.port>    lookup:service
 
 command jobs  run_job Shell <services>/topic_top.tsl
 command hosts connect_inet localhost:<tachikoma.topic_top.port> topic_top:service

--- a/etc/scripts/workstation/default.tsl
+++ b/etc/scripts/workstation/default.tsl
@@ -129,8 +129,8 @@ command hosts connect_inet localhost:<tachikoma.tables.port>    tables:service
 command jobs  run_job Shell <services>/engines.tsl
 command hosts connect_inet localhost:<tachikoma.engines.port>   engines:service
 
-command jobs  run_job Shell <services>/hunter.tsl
-command hosts connect_inet localhost:<tachikoma.hunter.port>    hunter:service
+command jobs  run_job Shell <services>/lookup.tsl
+command hosts connect_inet localhost:<tachikoma.lookup.port>    lookup:service
 
 command jobs  run_job Shell <services>/topic_top.tsl
 command hosts connect_inet localhost:<tachikoma.topic_top.port> topic_top:service

--- a/etc/scripts/workstation/misa.pl
+++ b/etc/scripts/workstation/misa.pl
@@ -20,7 +20,7 @@ fsync_source(
     pedantic   => 1,
     count      => 0,
     broadcasts => [],
-    no_probe   => 1
+    probe      => 0
 );
 fsync_destination(
     path    => '<home>/Documents',

--- a/etc/scripts/workstation/nyx.tsl
+++ b/etc/scripts/workstation/nyx.tsl
@@ -129,8 +129,8 @@ command hosts connect_inet localhost:<tachikoma.tables.port>    tables:service
 command jobs  run_job Shell <services>/engines.tsl
 command hosts connect_inet localhost:<tachikoma.engines.port>   engines:service
 
-command jobs  run_job Shell <services>/hunter.tsl
-command hosts connect_inet localhost:<tachikoma.hunter.port>    hunter:service
+command jobs  run_job Shell <services>/lookup.tsl
+command hosts connect_inet localhost:<tachikoma.lookup.port>    lookup:service
 
 command jobs  run_job Shell <services>/topic_top.tsl
 command hosts connect_inet localhost:<tachikoma.topic_top.port> topic_top:service

--- a/etc/scripts/workstation/services/config.tsl
+++ b/etc/scripts/workstation/services/config.tsl
@@ -9,7 +9,7 @@ var tachikoma.tables.http.port      = 3124;
 var tachikoma.tables.port           = 5100;
 var tachikoma.engines.port          = 5200;
 var tachikoma.indexers.port         = 5300;
-var tachikoma.hunter.port           = 5400;
+var tachikoma.lookup.port           = 5400;
 var tachikoma.hubs.port             = 5500;
 var tachikoma.topic_top.hostname    = localhost;
 var tachikoma.topic_top.port        = 4380;
@@ -20,6 +20,12 @@ var tachikoma.http.port             = 4241;
 var hub       = localhost:5501;
 var broker    = <hub>/broker;
 var topic_top = <tachikoma.topic_top.hostname>:<tachikoma.topic_top.input.port>;
+
+var server_log.fields = (
+    hostname
+    timestamp
+    process
+);
 
 func connect_hub {
     connect_inet <hub> <hub>;

--- a/etc/scripts/workstation/services/engines.tsl
+++ b/etc/scripts/workstation/services/engines.tsl
@@ -9,63 +9,23 @@ for i (1 .. 2) {
     cd engine<i>;
         connect_hub;
 
+        # server log indexes
+        var indexes = '';
+        for field (<server_log.fields>) {
+            make_node ConsumerBroker server_log.<field>:consumer --broker=<broker>
+                                                                 --topic=server_log.<field>
+                                                                 --group=engine
+                                                                 --default_offset=start
+                                                                 --cache_dir=<cache_dir>
+                                                                 --auto_commit=300;
+            make_node Index          server_log.<field>:index    --num_partitions=4
+                                                                 --window_size=86400
+                                                                 --num_buckets=7;
+            connect_edge server_log.<field>:consumer server_log.<field>:index;
+            var indexes .= server_log.<field>:index;
+        };
 
-        # timestamps
-        make_node ConsumerBroker server_log.timestamp:consumer
-                                 --broker=<broker>
-                                 --topic=server_log.timestamp
-                                 --group=timestamps.<hostname>
-                                 --default_offset=start
-                                 --cache_dir=<cache_dir>
-                                 --auto_commit=<auto_commit>;
-
-        make_node Index          server_log.timestamp:index
-                                 --num_partitions=4
-                                 --window_size=86400
-                                 --num_buckets=7;
-
-        connect_edge server_log.timestamp:consumer server_log.timestamp:index;
-
-
-        # hostnames
-        make_node ConsumerBroker server_log.hostname:consumer
-                                 --broker=<broker>
-                                 --topic=server_log.hostname
-                                 --group=hostnames.<hostname>
-                                 --default_offset=start
-                                 --cache_dir=<cache_dir>
-                                 --auto_commit=<auto_commit>;
-
-        make_node Index          server_log.hostname:index
-                                 --num_partitions=4
-                                 --window_size=86400
-                                 --num_buckets=7;
-
-        connect_edge server_log.hostname:consumer server_log.hostname:index;
-
-
-        # processes
-        make_node ConsumerBroker server_log.process:consumer
-                                 --broker=<broker>
-                                 --topic=server_log.process
-                                 --group=processes.<hostname>
-                                 --default_offset=start
-                                 --cache_dir=<cache_dir>
-                                 --auto_commit=<auto_commit>;
-
-        make_node Index          server_log.process:index
-                                 --num_partitions=4
-                                 --window_size=86400
-                                 --num_buckets=7;
-
-        connect_edge server_log.process:consumer server_log.process:index;
-
-
-        make_node QueryEngine QueryEngine server_log.timestamp:index
-                                          server_log.hostname:index
-                                          server_log.process:index;
-
-
+        make_node QueryEngine QueryEngine <indexes>;
         topic_probe;
         listen_inet <hostname>:<my_port>;
         secure 3;

--- a/etc/scripts/workstation/services/hubs.tsl
+++ b/etc/scripts/workstation/services/hubs.tsl
@@ -29,40 +29,28 @@ func add_hub {
             for hub (<all_hubs>) {
                 set_broker <hub>;
             };
+
             set_topic topic1;
-            set_group cache.nyx            --topic=topic1;
-            set_group cache.misa           --topic=topic1;
+            set_group cache                --topic=topic1;
             set_group IDs                  --topic=topic1;
+
             set_topic topic1.ID            --segment_size=(16 * 1024 * 1024);
-            set_group IDs.nyx              --topic=topic1.ID;
-            set_group IDs.misa             --topic=topic1.ID;
+            set_group IDs                  --topic=topic1.ID;
 
             set_topic topic2;
             set_group cache                --topic=topic2;
 
             set_topic server_log           --num_partitions=4
-                                           --segment_size=(64 * 1024 * 1024);
-            set_topic server_log.timestamp --num_partitions=4
-                                           --segment_size=(4 * 1024 * 1024);
-            set_topic server_log.hostname  --num_partitions=4
-                                           --segment_size=(4 * 1024 * 1024);
-            set_topic server_log.process   --num_partitions=4
-                                           --segment_size=(4 * 1024 * 1024);
-            set_group timestamps           --topic=server_log;
-            set_group timestamps.nyx       --topic=server_log.timestamp
-                                           --cache_size=0;
-            set_group timestamps.misa      --topic=server_log.timestamp
-                                           --cache_size=0;
-            set_group hostnames            --topic=server_log;
-            set_group hostnames.nyx        --topic=server_log.hostname
-                                           --cache_size=0;
-            set_group hostnames.misa       --topic=server_log.hostname
-                                           --cache_size=0;
-            set_group processes            --topic=server_log;
-            set_group processes.nyx        --topic=server_log.process
-                                           --cache_size=0;
-            set_group processes.misa       --topic=server_log.process
-                                           --cache_size=0;
+                                           --segment_size=(64 * 1024 * 1024)
+                                           --segment_lifespan=(7 * 86400);
+            for field (<server_log.fields>) {
+                set_topic --topic=server_log.<field> --num_partitions=4
+                                                     --segment_size=(4 * 1024 * 1024)
+                                                     --segment_lifespan=(7 * 86400);
+                set_group --group=server_log.<field> --topic=server_log;
+                set_group --group=engine             --topic=server_log.<field>
+                                                     --cache_size=0;
+            };
 
             set_topic images.ondisk  --num_partitions=8
                                      --segment_size=(128 * 1024 * 1024);

--- a/etc/scripts/workstation/services/indexers.tsl
+++ b/etc/scripts/workstation/services/indexers.tsl
@@ -25,11 +25,11 @@ connect_node topic1:consumer IndexByStream/topic1.ID
 
 
 # timestamps
-make_node ConsumerBroker   server_log:consumer1 --broker=<broker>      \
-                                                --topic=server_log     \
-                                                --group=timestamps     \
-                                                --default_offset=start \
-                                                --max_unanswered=64    \
+make_node ConsumerBroker   server_log:consumer1 --broker=<broker>            \
+                                                --topic=server_log           \
+                                                --group=server_log.timestamp \
+                                                --default_offset=start       \
+                                                --max_unanswered=64          \
                                                 --auto_commit=60
 
 make_node IndexByTimestamp IndexByTimestamp
@@ -38,11 +38,11 @@ connect_node server_log:consumer1 IndexByTimestamp/server_log.timestamp
 
 
 # hostnames
-make_node ConsumerBroker   server_log:consumer2 --broker=<broker>      \
-                                                --topic=server_log     \
-                                                --group=hostnames      \
-                                                --default_offset=start \
-                                                --max_unanswered=64    \
+make_node ConsumerBroker   server_log:consumer2 --broker=<broker>           \
+                                                --topic=server_log          \
+                                                --group=server_log.hostname \
+                                                --default_offset=start      \
+                                                --max_unanswered=64         \
                                                 --auto_commit=60
 
 make_node IndexByHostname  IndexByHostname
@@ -51,11 +51,11 @@ connect_node server_log:consumer2 IndexByHostname/server_log.hostname
 
 
 # processes
-make_node ConsumerBroker   server_log:consumer3 --broker=<broker>      \
-                                                --topic=server_log     \
-                                                --group=processes      \
-                                                --default_offset=start \
-                                                --max_unanswered=64    \
+make_node ConsumerBroker   server_log:consumer3 --broker=<broker>          \
+                                                --topic=server_log         \
+                                                --group=server_log.process \
+                                                --default_offset=start     \
+                                                --max_unanswered=64        \
                                                 --auto_commit=60
 
 make_node IndexByProcess   IndexByProcess

--- a/etc/scripts/workstation/services/lookup.tsl
+++ b/etc/scripts/workstation/services/lookup.tsl
@@ -1,13 +1,10 @@
 #!/usr/bin/env /usr/local/bin/tachikoma
-var name = hunter;
+var name = lookup;
 include services/daemonize.tsl
 
 var start = 0;
 var count = 8;
-if (<hostname> eq "trantor") {
-    start += <count>;
-}
-var end = <start> + <count> - 1;
+var end   = <start> + <count> - 1;
 
 make_node Tee images
 for i (<start> .. <end>) {

--- a/etc/scripts/workstation/services/tables.tsl
+++ b/etc/scripts/workstation/services/tables.tsl
@@ -6,28 +6,28 @@ connect_hub
 
 
 # example of caching values for HTTP_Fetch
-make_node ConsumerBroker topic1:consumer    --broker=<broker>        \
-                                            --topic=topic1           \
-                                            --group=cache.<hostname> \
-                                            --default_offset=start   \
+make_node ConsumerBroker topic1:consumer    --broker=<broker>      \
+                                            --topic=topic1         \
+                                            --group=cache          \
+                                            --default_offset=start \
                                             --auto_commit=60
 
-make_node Table          topic1:table       --num_partitions=1       \
-                                            --window_size=0          \
+make_node Table          topic1:table       --num_partitions=1     \
+                                            --window_size=0        \
                                             --num_buckets=1
 
 connect_edge topic1:consumer topic1:table
 
 
 # example of caching offsets for fetch.cgi
-make_node ConsumerBroker topic1.ID:consumer --broker=<broker>        \
-                                            --topic=topic1.ID        \
-                                            --group=IDs.<hostname>   \
-                                            --default_offset=start   \
+make_node ConsumerBroker topic1.ID:consumer --broker=<broker>      \
+                                            --topic=topic1.ID      \
+                                            --group=IDs            \
+                                            --default_offset=start \
                                             --auto_commit=60
 
-make_node Table          topic1.ID:table    --num_partitions=1       \
-                                            --window_size=0          \
+make_node Table          topic1.ID:table    --num_partitions=1     \
+                                            --window_size=0        \
                                             --num_buckets=1
 
 connect_edge topic1.ID:consumer topic1.ID:table

--- a/examples/benchmarks/query
+++ b/examples/benchmarks/query
@@ -31,7 +31,7 @@ usage() if ( $help or not $r or not $topic );
 
 die "ERROR: no topic\n"    if ( not $topic );
 my $engine = Tachikoma::Nodes::QueryEngine->new;
-$engine->hosts([ 'localhost:5201', 'localhost:5202' ]);
+$engine->hosts({ 'localhost' => [ 5201 .. 5202 ] });
 $engine->topic($topic);
 my $query = [];
 

--- a/examples/topics/query
+++ b/examples/topics/query
@@ -33,7 +33,7 @@ usage() if ( $help or not $r or not $topic );
 
 die "ERROR: no topic\n"    if ( not $topic );
 my $engine = Tachikoma::Nodes::QueryEngine->new;
-$engine->hosts([ 'localhost:5201', 'localhost:5202' ]);
+$engine->hosts({ 'localhost' => [ 5201 .. 5202 ] });
 $engine->topic($topic);
 my $json = JSON->new;
 $json->canonical(1);

--- a/lib/Accessories/Forks.pm
+++ b/lib/Accessories/Forks.pm
@@ -14,7 +14,7 @@ use Tachikoma::Nodes::JobFarmer;
 use Tachikoma::Nodes::Router;
 use Tachikoma::Nodes::STDIO qw( TK_SYNC );
 use Tachikoma::Nodes::Timer;
-use Tachikoma::Message qw( TM_BYTESTREAM TM_EOF TM_ERROR );
+use Tachikoma::Message qw( TM_BYTESTREAM TM_ERROR TM_EOF );
 use Tachikoma::Config qw( %Tachikoma );
 use Data::Dumper;
 

--- a/lib/Accessories/Nodes/IndexByHostname.pm
+++ b/lib/Accessories/Nodes/IndexByHostname.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM TIMESTAMP PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR
+    TM_BYTESTREAM TM_PERSIST
 );
 use parent qw( Tachikoma::Node );
 
@@ -20,9 +20,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     $self->{counter}++;
-    return
-        if ( $message->[TYPE] & TM_RESPONSE
-        or $message->[TYPE] & TM_ERROR );
+    return if ( not $message->[TYPE] & TM_BYTESTREAM );
     my $partition = ( $message->[FROM] =~ m{(\d+)$} )[0];
     my $offset    = ( split m{:}, $message->[ID], 2 )[0] // 0;
     my $hostname  = ( split q( ), $message->[PAYLOAD], 5 )[3] // '-';

--- a/lib/Accessories/Nodes/IndexByProcess.pm
+++ b/lib/Accessories/Nodes/IndexByProcess.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM TIMESTAMP PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR
+    TM_BYTESTREAM TM_PERSIST
 );
 use parent qw( Tachikoma::Node );
 
@@ -20,9 +20,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     $self->{counter}++;
-    return
-        if ( $message->[TYPE] & TM_RESPONSE
-        or $message->[TYPE] & TM_ERROR );
+    return if ( not $message->[TYPE] & TM_BYTESTREAM );
     my $partition = ( $message->[FROM] =~ m{(\d+)$} )[0];
     my $offset    = ( split m{:}, $message->[ID], 2 )[0] // 0;
     my $process   = ( split q( ), $message->[PAYLOAD], 6 )[4] // '-';

--- a/lib/Accessories/Nodes/SFESerLCD.pm
+++ b/lib/Accessories/Nodes/SFESerLCD.pm
@@ -100,7 +100,7 @@ sub fire {
     return if ( ( $now - $last ) < $min );
     return if ( $now < $until );
     $self->{waiting_until} = 0;
-    my $str = shift( @{ $self->{queue} } );
+    my $str = shift( @{ $self->{queue} } ) // q();
 
     if ( $str =~ /^WAIT:(\d+)$/ ) {
         my $s = $1;

--- a/lib/Accessories/Nodes/Smooth.pm
+++ b/lib/Accessories/Nodes/Smooth.pm
@@ -64,8 +64,8 @@ sub fill {
 sub fire {
     my $self = shift;
 
-    my $last   = $self->{last_out};
-    my $target = $self->{target_out};
+    my $last   = $self->{last_out} // 0;
+    my $target = $self->{target_out} // 0;
 
     my $newmsg = Tachikoma::Message->new;
     $newmsg->type(TM_BYTESTREAM);

--- a/lib/Tachikoma/Job.pm
+++ b/lib/Tachikoma/Job.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Job
 # ----------------------------------------------------------------------
 #
-# $Id: Job.pm 35416 2018-10-20 07:15:03Z chris $
+# $Id: Job.pm 35477 2018-10-21 13:27:41Z chris $
 #
 
 package Tachikoma::Job;
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO PAYLOAD
-    TM_EOF TM_ERROR
+    TM_ERROR TM_EOF
 );
 use Tachikoma::Nodes::FileHandle qw( TK_R setsockopts );
 use Tachikoma::Nodes::STDIO;

--- a/lib/Tachikoma/Jobs/TailFork.pm
+++ b/lib/Tachikoma/Jobs/TailFork.pm
@@ -15,7 +15,7 @@ use Tachikoma::Nodes::Tail;
 use Tachikoma::Nodes::Timer;
 use Tachikoma::Message qw(
     TYPE FROM TO ID PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_EOF TM_ERROR
+    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR TM_EOF
 );
 use Data::Dumper;
 use parent qw( Tachikoma::Job );

--- a/lib/Tachikoma/Jobs/TailFork.pm
+++ b/lib/Tachikoma/Jobs/TailFork.pm
@@ -99,7 +99,7 @@ sub fill {
         $self->{timer}->remove_node;
     }
     elsif ( $message->[PAYLOAD] eq "delete\n" ) {
-        $self->{tail}->on_EOF('close');
+        $self->{tail}->on_EOF('wait_to_close');
         $self->{timer}->remove_node;
     }
     elsif ( $message->[PAYLOAD] =~ m{^dump(?:\s+(\S+))?\n$} ) {

--- a/lib/Tachikoma/Jobs/TailFork.pm
+++ b/lib/Tachikoma/Jobs/TailFork.pm
@@ -79,6 +79,7 @@ sub fill {
     elsif ( $message->[FROM] eq 'Tail' ) {
         $message->[FROM] = $self->{name};
         $self->{destination}->fill($message);
+        $self->shutdown_all_nodes if ( $message->[TYPE] & TM_EOF );
     }
     elsif ( $message->[TYPE] & TM_RESPONSE ) {
         $self->{offset} = $message->[ID];

--- a/lib/Tachikoma/Nodes/Atom.pm
+++ b/lib/Tachikoma/Nodes/Atom.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::Atom;
 use strict;
 use warnings;
 use Tachikoma::Node;
-use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM TM_ERROR );
+use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM TM_ERROR TM_EOF );
 use File::MkTemp;
 use parent qw( Tachikoma::Node );
 
@@ -51,7 +51,7 @@ sub fill {
     my $message = shift;
     my $tmp_dir = $self->{tmp_dir};
     my $path    = $self->{path};
-    return if ( $message->[TYPE] == TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     return $self->stderr('ERROR: no path set') if ( not $path );
     return $self->stderr('ERROR: unexpected payload')
         if ( not $message->[TYPE] & TM_BYTESTREAM );

--- a/lib/Tachikoma/Nodes/Broker.pm
+++ b/lib/Tachikoma/Nodes/Broker.pm
@@ -83,7 +83,7 @@ sub new {
     $self->{last_check}          = undef;
     $self->{last_delete}         = undef;
     $self->{last_save}           = undef;
-    $self->{last_election}       = undef;
+    $self->{last_election}       = $Tachikoma::Now;
     $self->{last_halt}           = 0;
     $self->{last_reset}          = 0;
     $self->{mapping}             = {};

--- a/lib/Tachikoma/Nodes/Broker.pm
+++ b/lib/Tachikoma/Nodes/Broker.pm
@@ -305,7 +305,7 @@ sub fire {    ## no critic (ProhibitExcessComplexity)
     }
     my $total  = keys %{ $self->{brokers} };
     my $online = $self->check_heartbeats;
-    if ( $online < $total / 2 ) {
+    if ( not $total or $online < $total / 2 ) {
         $self->print_less_often('ERROR: not enough servers')
             if ( not $self->{starting_up} );
         $self->rebalance_partitions('inform_brokers');

--- a/lib/Tachikoma/Nodes/Bucket.pm
+++ b/lib/Tachikoma/Nodes/Bucket.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::Bucket;
 use strict;
 use warnings;
 use Tachikoma::Nodes::Timer;
-use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM TM_ERROR );
+use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM TM_ERROR TM_EOF );
 use POSIX qw( strftime );
 use parent qw( Tachikoma::Nodes::Timer );
 
@@ -53,7 +53,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     my $base    = $self->{base};
-    return if ( $message->[TYPE] == TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     my ( $time, $payload ) = split q( ), $message->[PAYLOAD], 2;
     return $self->stderr('ERROR: unexpected payload')
         if ( not $message->[TYPE] & TM_BYTESTREAM or not $time );

--- a/lib/Tachikoma/Nodes/ClientConnector.pm
+++ b/lib/Tachikoma/Nodes/ClientConnector.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::ClientConnector;
 use strict;
 use warnings;
 use Tachikoma::Node;
-use Tachikoma::Message qw( TYPE FROM TM_INFO TM_EOF TM_ERROR );
+use Tachikoma::Message qw( TYPE FROM TM_INFO TM_ERROR TM_EOF );
 use parent qw( Tachikoma::Node );
 
 use version; our $VERSION = qv('v2.0.280');

--- a/lib/Tachikoma/Nodes/Consumer.pm
+++ b/lib/Tachikoma/Nodes/Consumer.pm
@@ -189,8 +189,11 @@ sub fill {    ## no critic (ProhibitExcessComplexity)
         }
     }
     else {
-        return $self->stderr('WARNING: unexpected message')
-            if ( not $self->{expecting} );
+        if ( not $self->{expecting} ) {
+            $self->stderr('WARNING: unexpected message')
+                if ( not $message->[TYPE] & TM_EOF );
+            return;
+        }
         $self->{offset} //= $offset;
         if (    $self->{next_offset} > 0
             and $offset != $self->{next_offset} )

--- a/lib/Tachikoma/Nodes/ConsumerBroker.pm
+++ b/lib/Tachikoma/Nodes/ConsumerBroker.pm
@@ -184,7 +184,7 @@ sub fill {
             delete $self->consumers->{$partition_id};
         }
     }
-    else {
+    elsif ( not $message->[TYPE] & TM_EOF ) {
         $self->stderr( 'INFO: ', $message->type_as_string, ' from ',
             $message->from );
     }

--- a/lib/Tachikoma/Nodes/Date.pm
+++ b/lib/Tachikoma/Nodes/Date.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO PAYLOAD
-    TM_BYTESTREAM TM_INFO TM_EOF TM_ERROR
+    TM_BYTESTREAM TM_INFO TM_ERROR TM_EOF
 );
 use POSIX qw( strftime );
 use parent qw( Tachikoma::Node );
@@ -27,7 +27,7 @@ use version; our $VERSION = 'v2.0.367';
 sub fill {
     my $self    = shift;
     my $message = shift;
-    return if ( $message->[TYPE] == TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     $self->{counter}++;
     my $response = Tachikoma::Message->new;
     $response->[TYPE] = TM_BYTESTREAM;

--- a/lib/Tachikoma/Nodes/FileController.pm
+++ b/lib/Tachikoma/Nodes/FileController.pm
@@ -118,7 +118,7 @@ sub fire {
     my $self = shift;
 
     # empty all the pools so the buffer can refill them
-    $self->stderr('WARNING: emptying event pools');
+    $self->stderr('WARNING: emptying event pools') if ( @{ $self->{pools} } );
     $self->{op}    = q();
     $self->{pools} = [];
     $self->stop_timer;

--- a/lib/Tachikoma/Nodes/FileHandle.pm
+++ b/lib/Tachikoma/Nodes/FileHandle.pm
@@ -324,6 +324,7 @@ sub close_filehandle {
         if ($self->{fh}
         and fileno $self->{fh}
         and not close $self->{fh}
+        and $!
         and $! ne 'Connection reset by peer'
         and $! ne 'Broken pipe' );
     POSIX::close( $self->{fd} ) if ( defined $self->{fd} );

--- a/lib/Tachikoma/Nodes/FileHandle.pm
+++ b/lib/Tachikoma/Nodes/FileHandle.pm
@@ -6,7 +6,7 @@
 # Tachikomatic IPC - send and receive messages over filehandles
 #                  - on_EOF: close, send, ignore
 #
-# $Id: FileHandle.pm 35372 2018-10-18 05:15:40Z chris $
+# $Id: FileHandle.pm 35454 2018-10-21 03:23:40Z chris $
 #
 
 package Tachikoma::Nodes::FileHandle;

--- a/lib/Tachikoma/Nodes/FileHandle.pm
+++ b/lib/Tachikoma/Nodes/FileHandle.pm
@@ -6,7 +6,7 @@
 # Tachikomatic IPC - send and receive messages over filehandles
 #                  - on_EOF: close, send, ignore
 #
-# $Id: FileHandle.pm 35454 2018-10-21 03:23:40Z chris $
+# $Id: FileHandle.pm 35477 2018-10-21 13:27:41Z chris $
 #
 
 package Tachikoma::Nodes::FileHandle;
@@ -15,7 +15,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO PAYLOAD
-    TM_BYTESTREAM TM_EOF TM_ERROR
+    TM_BYTESTREAM TM_ERROR TM_EOF
     VECTOR_SIZE
 );
 use Tachikoma::Config qw( %Tachikoma );

--- a/lib/Tachikoma/Nodes/FileWatcher.pm
+++ b/lib/Tachikoma/Nodes/FileWatcher.pm
@@ -1,0 +1,118 @@
+#!/usr/bin/perl
+# ----------------------------------------------------------------------
+# Tachikoma::Nodes::FileWatcher
+# ----------------------------------------------------------------------
+#
+# $Id: FileWatcher.pm 20143 2014-07-29 23:15:57Z chris $
+#
+
+package Tachikoma::Nodes::FileWatcher;
+use strict;
+use warnings;
+use Tachikoma::Nodes::Timer;
+use Tachikoma::Message qw( TYPE FROM TO PAYLOAD TM_BYTESTREAM );
+use parent qw( Tachikoma::Nodes::Timer );
+
+use version; our $VERSION = 'v2.0.367';
+
+my $Check_Interval_Min = 0.02;
+my $Check_Interval_Max = 10;
+
+sub new {
+    my $class = shift;
+    my $self  = $class->SUPER::new;
+    $self->{files} = {};
+    $self->{queue} = [];
+    bless $self, $class;
+    return $self;
+}
+
+sub help {
+    my $self = shift;
+    return <<'EOF';
+make_node FileWatcher <node name>
+EOF
+}
+
+sub arguments {
+    my $self = shift;
+    if (@_) {
+        $self->{arguments} = shift;
+    }
+    return $self->{arguments};
+}
+
+sub fill {
+    my $self    = shift;
+    my $message = shift;
+    return if ( not $message->[TYPE] & TM_BYTESTREAM );
+    my $file = ( $message->[PAYLOAD] =~ m{^(/.*)$} )[0];
+    return if ( not $file );
+    $self->{files}->{$file} = -e $file ? ( stat _ )[1] : undef;
+    $self->queue if ( not $self->{timer_is_active} );
+    return;
+}
+
+sub fire {
+    my $self      = shift;
+    my $file      = shift @{ $self->queue } or return;
+    my $old_inode = $self->{files}->{$file};
+    my $new_inode = undef;
+    my $payload   = undef;
+    if ( -e $file ) {
+        $new_inode = ( stat _ )[1];
+        if ( defined $old_inode ) {
+            if ( $new_inode != $old_inode ) {
+                $payload = "$self->{name}: file $file inode changed\n";
+            }
+        }
+        else {
+            $payload = "$self->{name}: file $file created\n";
+        }
+    }
+    elsif ( defined $old_inode ) {
+        $payload = "$self->{name}: file $file missing\n";
+    }
+    $self->{files}->{$file} = $new_inode;
+    if ($payload) {
+        my $message = Tachikoma::Message->new;
+        $message->[TYPE] = TM_BYTESTREAM;
+        $message->[FROM] = $self->{name};
+        $message->[TO]   = $self->{owner};
+        $message->payload($payload);
+        $self->{counter}++;
+        $self->{sink}->fill($message);
+    }
+    return;
+}
+
+sub files {
+    my $self = shift;
+    if (@_) {
+        $self->{files} = shift;
+    }
+    return $self->{files};
+}
+
+sub queue {
+    my $self = shift;
+    if (@_) {
+        $self->{queue} = shift;
+    }
+    if ( not @{ $self->{queue} } ) {
+        my $queue = [ sort keys %{ $self->{files} } ];
+        $self->{queue} = $queue;
+        my $count = @{$queue};
+        if ($count) {
+            my $time = $Check_Interval_Max / $count;
+            $time = $Check_Interval_Min if ( $time < $Check_Interval_Min );
+            $self->set_timer( $time * 1000 );
+        }
+        else {
+            $self->stop_timer;
+        }
+    }
+    return $self->{queue};
+}
+
+1;

--- a/lib/Tachikoma/Nodes/IndexByStream.pm
+++ b/lib/Tachikoma/Nodes/IndexByStream.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM TIMESTAMP PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR
+    TM_BYTESTREAM TM_PERSIST TM_ERROR TM_EOF
 );
 use parent qw( Tachikoma::Node );
 
@@ -22,9 +22,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     $self->{counter}++;
-    return
-        if ( $message->[TYPE] & TM_RESPONSE
-        or $message->[TYPE] & TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     my $partition = ( $message->[FROM] =~ m{(\d+)$} )[0];
     my $offset    = ( split m{:}, $message->[ID], 2 )[0] // 0;
     my $response  = Tachikoma::Message->new;

--- a/lib/Tachikoma/Nodes/IndexByTimestamp.pm
+++ b/lib/Tachikoma/Nodes/IndexByTimestamp.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Node;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM TIMESTAMP PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR
+    TM_BYTESTREAM TM_PERSIST TM_ERROR TM_EOF
 );
 use parent qw( Tachikoma::Node );
 
@@ -22,9 +22,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     $self->{counter}++;
-    return
-        if ( $message->[TYPE] & TM_RESPONSE
-        or $message->[TYPE] & TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     my $timestamp = $message->[TIMESTAMP] - $message->[TIMESTAMP] % 60;
     my $partition = ( $message->[FROM] =~ m{(\d+)$} )[0];
     my $offset    = ( split m{:}, $message->[ID], 2 )[0] // 0;

--- a/lib/Tachikoma/Nodes/LoadBalancer.pm
+++ b/lib/Tachikoma/Nodes/LoadBalancer.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::LoadBalancer
 # ----------------------------------------------------------------------
 #
-# $Id: LoadBalancer.pm 35420 2018-10-20 09:48:46Z chris $
+# $Id: LoadBalancer.pm 35477 2018-10-21 13:27:41Z chris $
 #
 
 package Tachikoma::Nodes::LoadBalancer;
@@ -13,7 +13,7 @@ use Tachikoma::Nodes::Timer;
 use Tachikoma::Nodes::CommandInterpreter;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM
-    TM_COMMAND TM_INFO TM_PERSIST TM_RESPONSE TM_EOF TM_ERROR
+    TM_COMMAND TM_INFO TM_PERSIST TM_RESPONSE TM_ERROR TM_EOF
 );
 use Digest::MD5 qw( md5 );
 use parent qw( Tachikoma::Nodes::Timer );

--- a/lib/Tachikoma/Nodes/Log.pm
+++ b/lib/Tachikoma/Nodes/Log.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::Log
 # ----------------------------------------------------------------------
 #
-# $Id: Log.pm 35353 2018-10-17 08:17:26Z chris $
+# $Id: Log.pm 35477 2018-10-21 13:27:41Z chris $
 #
 
 package Tachikoma::Nodes::Log;
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 use Tachikoma::Nodes::FileHandle qw( TK_SYNC );
 use Tachikoma::Nodes::STDIO;
-use Tachikoma::Message qw( TYPE FROM STREAM PAYLOAD TM_INFO TM_EOF TM_ERROR );
+use Tachikoma::Message qw( TYPE FROM STREAM PAYLOAD TM_INFO TM_ERROR TM_EOF );
 use POSIX qw( strftime );
 use parent qw( Tachikoma::Nodes::FileHandle );
 

--- a/lib/Tachikoma/Nodes/QueryEngine.pm
+++ b/lib/Tachikoma/Nodes/QueryEngine.pm
@@ -12,7 +12,7 @@ use warnings;
 use Tachikoma::Nodes::Index;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM PAYLOAD
-    TM_BYTESTREAM TM_STORABLE TM_ERROR
+    TM_BYTESTREAM TM_STORABLE TM_ERROR TM_EOF
 );
 use parent qw( Tachikoma::Nodes::Index );
 
@@ -66,7 +66,9 @@ sub fill {
         $self->{sink}->fill($response);
         $self->{counter}++;
     }
-    elsif ( $message->[TYPE] != TM_ERROR ) {
+    elsif ( not $message->[TYPE] & TM_ERROR
+        and not $message->[TYPE] & TM_EOF )
+    {
         $self->stderr( 'ERROR: bad request from: ', $message->[FROM] );
     }
     return;

--- a/lib/Tachikoma/Nodes/Queue.pm
+++ b/lib/Tachikoma/Nodes/Queue.pm
@@ -575,6 +575,7 @@ sub dbh {
         }
         else {
             ## no critic (RequireCheckedSyscalls)
+            local %ENV = ();
             system "/bin/rm -f ${path}*";
         }
         my $dbh = DBI->connect("dbi:SQLite:dbname=$path");

--- a/lib/Tachikoma/Nodes/RandomSieve.pm
+++ b/lib/Tachikoma/Nodes/RandomSieve.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::RandomSieve;
 use strict;
 use warnings;
 use Tachikoma::Nodes::Echo;
-use Tachikoma::Message qw( TYPE FROM TO ID STREAM PAYLOAD TM_ERROR );
+use Tachikoma::Message qw( TYPE FROM TO ID STREAM PAYLOAD TM_ERROR TM_EOF );
 use parent qw( Tachikoma::Nodes::Echo );
 
 use version; our $VERSION = qv('v2.0.280');
@@ -42,7 +42,7 @@ sub arguments {
 sub fill {
     my $self    = shift;
     my $message = shift;
-    return if ( $message->[TYPE] == TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     if ( rand(100) >= $self->{probability} ) {
         my $response = Tachikoma::Message->new;
         $response->[TYPE]    = TM_ERROR;

--- a/lib/Tachikoma/Nodes/Rewrite.pm
+++ b/lib/Tachikoma/Nodes/Rewrite.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::Rewrite;
 use strict;
 use warnings;
 use Tachikoma::Node;
-use Tachikoma::Message qw( PAYLOAD );
+use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM );
 use parent qw( Tachikoma::Node );
 
 use version; our $VERSION = 'v2.0.368';
@@ -49,6 +49,7 @@ sub arguments {
 sub fill {
     my $self    = shift;
     my $message = shift;
+    return if ( not $message->[TYPE] & TM_BYTESTREAM );
     my $payload = $message->[PAYLOAD];
     my $pattern = $self->{pattern};
     my $rewrite = $self->{rewrite};

--- a/lib/Tachikoma/Nodes/Socket.pm
+++ b/lib/Tachikoma/Nodes/Socket.pm
@@ -513,9 +513,13 @@ sub init_SSL_connection {
         # complaining about missing entries in %Nodes_By_FD
         $self->unregister_reader_node;
         $self->unregister_writer_node;
-        if ( $self->{fh} and fileno $self->{fh} ) {
-            close $self->{fh} or $self->stderr("WARNING: couldn't close: $!");
-        }
+        $self->stderr("WARNING: couldn't close: $!")
+            if ($self->{fh}
+            and fileno $self->{fh}
+            and not close $self->{fh}
+            and $!
+            and $! ne 'Connection reset by peer'
+            and $! ne 'Broken pipe' );
         $self->{fh} = undef;
         $self->handle_EOF;
     }

--- a/lib/Tachikoma/Nodes/Substr.pm
+++ b/lib/Tachikoma/Nodes/Substr.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::Substr;
 use strict;
 use warnings;
 use Tachikoma::Node;
-use Tachikoma::Message qw( PAYLOAD );
+use Tachikoma::Message qw( TYPE PAYLOAD TM_BYTESTREAM );
 use parent qw( Tachikoma::Node );
 
 use version; our $VERSION = qv('v2.0.280');
@@ -44,6 +44,7 @@ sub arguments {
 sub fill {
     my $self    = shift;
     my $message = shift;
+    return if ( not $message->[TYPE] & TM_BYTESTREAM );
     my $payload = $message->[PAYLOAD];
     my @matches = $payload =~ m{$self->{pattern}};
     return $self->cancel($message) if ( not @matches );

--- a/lib/Tachikoma/Nodes/Table.pm
+++ b/lib/Tachikoma/Nodes/Table.pm
@@ -14,7 +14,7 @@ use Tachikoma::Nodes::Timer;
 use Tachikoma;
 use Tachikoma::Message qw(
     TYPE FROM TO ID STREAM TIMESTAMP PAYLOAD
-    TM_BYTESTREAM TM_STORABLE TM_INFO
+    TM_BYTESTREAM TM_STORABLE TM_INFO TM_ERROR TM_EOF
 );
 use Digest::MD5 qw( md5 );
 use Getopt::Long qw( GetOptionsFromString );
@@ -110,7 +110,9 @@ sub fill {
             );
         }
     }
-    else {
+    elsif ( not $message->[TYPE] & TM_ERROR
+        and not $message->[TYPE] & TM_EOF )
+    {
         $self->store( $message->[TIMESTAMP], $message->[STREAM],
             $message->payload );
         $self->cancel($message);

--- a/lib/Tachikoma/Nodes/Tail.pm
+++ b/lib/Tachikoma/Nodes/Tail.pm
@@ -7,7 +7,7 @@
 #             wait_to_send, wait_to_close, wait_to_delete,
 #             wait_for_delete, wait_for_a_while
 #
-# $Id: Tail.pm 35424 2018-10-20 10:20:18Z chris $
+# $Id: Tail.pm 35477 2018-10-21 13:27:41Z chris $
 #
 
 package Tachikoma::Nodes::Tail;
@@ -18,7 +18,7 @@ use Tachikoma::Nodes::FileHandle;
 use Tachikoma::Nodes::STDIO;
 use Tachikoma::Message qw(
     TYPE FROM ID STREAM PAYLOAD
-    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR
+    TM_BYTESTREAM TM_PERSIST TM_RESPONSE TM_ERROR TM_EOF
 );
 use Tachikoma::Config qw( %Tachikoma %Forbidden );
 use Fcntl qw( SEEK_SET SEEK_CUR SEEK_END );
@@ -207,7 +207,9 @@ sub fill {
     return $self->check_timers($message) if ( not length $message->[FROM] );
     return $self->stderr( 'WARNING: unexpected response from ',
         $message->[FROM] )
-        if ( not $msg_unanswered and not $message->[TYPE] & TM_ERROR );
+        if (not $msg_unanswered
+        and not $message->[TYPE] & TM_ERROR
+        and not $message->[TYPE] & TM_EOF );
     return
         if ( not $max_unanswered
         or $message->[TYPE] != ( TM_PERSIST | TM_RESPONSE ) );

--- a/lib/Tachikoma/Nodes/Topic.pm
+++ b/lib/Tachikoma/Nodes/Topic.pm
@@ -71,6 +71,7 @@ sub arguments {
         my $arguments = shift;
         $self->{arguments} = $arguments;
         my ( $broker, $topic ) = split q( ), $arguments, 2;
+        die "ERROR: bad arguments for Topic\n" if ( not $broker );
         $self->{broker_path}    = $broker;
         $self->{topic}          = $topic // $self->{name};
         $self->{next_partition} = 0;

--- a/lib/Tachikoma/Nodes/Watchdog.pm
+++ b/lib/Tachikoma/Nodes/Watchdog.pm
@@ -10,7 +10,7 @@ package Tachikoma::Nodes::Watchdog;
 use strict;
 use warnings;
 use Tachikoma::Nodes::Timer;
-use Tachikoma::Message qw( TM_EOF TM_ERROR );
+use Tachikoma::Message qw( TYPE TM_ERROR TM_EOF );
 use parent qw( Tachikoma::Nodes::Timer );
 
 use version; our $VERSION = 'v2.0.367';
@@ -39,7 +39,7 @@ sub arguments {
 sub fill {
     my $self    = shift;
     my $message = shift;
-    return if ( $message->type == TM_ERROR );
+    return if ( $message->[TYPE] & TM_ERROR or $message->[TYPE] & TM_EOF );
     my $gate = $self->{gate} or return $self->stderr('ERROR: no gate set');
     my $node = $Tachikoma::Nodes{$gate}
         or return $self->stderr("ERROR: couldn't find $gate");
@@ -53,7 +53,7 @@ sub fill {
 
 sub fire {
     my $self = shift;
-    my $gate = $self->{gate} or return $self->stderr('ERROR: no gate set');
+    my $gate = $self->{gate} or return;
     my $node = $Tachikoma::Nodes{$gate}
         or return $self->stderr("ERROR: couldn't find $gate");
     return $self->stderr('ERROR: only Gate nodes are supported')

--- a/t/jobs.t
+++ b/t/jobs.t
@@ -18,9 +18,9 @@ sub test_construction {
     return $node;
 }
 
-my $class = 'Tachikoma';
-test_construction($class);
-$class->event_framework(
+my $tachikoma = 'Tachikoma';
+test_construction($tachikoma);
+$tachikoma->event_framework(
     test_construction('Tachikoma::EventFrameworks::Select') );
 
 my @jobs = qw(

--- a/t/nodes.t
+++ b/t/nodes.t
@@ -7,7 +7,7 @@
 #
 use strict;
 use warnings;
-use Test::More tests => 2420;
+use Test::More tests => 2444;
 use Tachikoma;
 use Tachikoma::Message qw( TM_ERROR );
 
@@ -120,6 +120,7 @@ my %nodes = (
     'Tachikoma::Nodes::FileController'        => q(),
     'Tachikoma::Nodes::FileReceiver'          => q(),
     'Tachikoma::Nodes::FileSender'            => q(),
+    'Tachikoma::Nodes::FileWatcher'           => q(),
     'Tachikoma::Nodes::Function'              => q({ return 1; }),
     'Tachikoma::Nodes::Gate'                  => q(),
     'Tachikoma::Nodes::Grep'                  => q(),

--- a/t/nodes.t
+++ b/t/nodes.t
@@ -7,7 +7,7 @@
 #
 use strict;
 use warnings;
-use Test::More tests => 3148;
+use Test::More tests => 3144;
 use Tachikoma;
 use Tachikoma::Message qw( TM_ERROR TM_EOF );
 
@@ -133,6 +133,7 @@ my %skip_owner_test = (
     'Tachikoma::Nodes::JobController' => 1,
     'Tachikoma::Nodes::HTTP_Route'    => 1,
     'Tachikoma::Nodes::LoadBalancer'  => 1,
+    'Tachikoma::Nodes::Queue'         => 1,
     'Tachikoma::Nodes::RegexTee'      => 1,
     'Tachikoma::Nodes::Tee'           => 1,
 );

--- a/t/nodes.t
+++ b/t/nodes.t
@@ -7,17 +7,9 @@
 #
 use strict;
 use warnings;
-use Test::More tests => 2444;
+use Test::More tests => 3148;
 use Tachikoma;
-use Tachikoma::Message qw( TM_ERROR );
-
-my $taint = undef;
-{
-    local $/ = undef;
-    open my $fh, '<', '/dev/null';
-    $taint = <$fh>;
-    close $fh;
-}
+use Tachikoma::Message qw( TM_ERROR TM_EOF );
 
 sub test_construction {
     my $class = shift;
@@ -28,64 +20,10 @@ sub test_construction {
     return $node;
 }
 
-my $class = 'Tachikoma';
-test_construction($class);
-$class->event_framework(
+my $tachikoma = 'Tachikoma';
+test_construction($tachikoma);
+$tachikoma->event_framework(
     test_construction('Tachikoma::EventFrameworks::Select') );
-
-my $router    = test_construction('Tachikoma::Nodes::Router');
-my $responder = test_construction('Tachikoma::Nodes::Responder');
-my $shell     = test_construction('Tachikoma::Nodes::Shell2');
-my $trap      = test_construction('Tachikoma::Nodes::Callback');
-
-$router->name('_router');
-$responder->name('_responder');
-$responder->shell($shell);
-
-$Tachikoma::Now       = time;
-$Tachikoma::Right_Now = time;
-
-sub test_node {
-    my $node      = shift;
-    my $test_args = shift;
-    my $class     = ref $node;
-    my $name      = lc $class;
-    $name =~ s{.*:}{};
-    is( $node->name($name),       $name, "$class->name can be set" );
-    is( $node->name,              $name, "$class->name is set correctly" );
-    is( $Tachikoma::Nodes{$name}, $node, "$class->name is ok" );
-    if ( defined $test_args ) {
-        $test_args .= $taint;
-        is( $node->arguments($test_args),
-            $test_args, "$class->arguments can be set" );
-        is( $node->arguments, $test_args,
-            "$class->arguments are set correctly" );
-        is( $node->sink($trap), $trap, "$class->sink can be set" );
-        is( $node->sink,        $trap, "$class->sink is set correctly" );
-        $trap->callback(
-            sub {
-                my $message = shift;
-                is( $message->from, $class,
-                    "$class->fill does not stamp errors" );
-                is( $message->to, q(), "$class->fill does not route errors" );
-                is( $message->payload, "NOT_AVAILABLE\n",
-                    "$class->fill does not rewrite errors" );
-                return;
-            }
-        );
-        my $message = Tachikoma::Message->new;
-        $message->type(TM_ERROR);
-        $message->from($class);
-        $message->payload( "NOT_AVAILABLE\n" . $taint );
-        is( $node->fill($message), undef, "$class->fill returns undef" );
-    }
-    is( $node->remove_node, undef, "$class->remove_node returns undef" );
-    while ( my $close_cb = shift @Tachikoma::Closing ) {
-        &{$close_cb}();
-    }
-    is( $Tachikoma::Nodes{$name}, undef, "$class->remove_node is ok" );
-    return;
-}
 
 my $t     = "/tmp/tachikoma.test.$$";
 my %nodes = (
@@ -107,7 +45,7 @@ my %nodes = (
     'Tachikoma::Nodes::Callback'              => undef,
     'Tachikoma::Nodes::CGI'                   => undef,
     'Tachikoma::Nodes::CircuitTester'         => q(),
-    'Tachikoma::Nodes::ClientConnector'       => q(),
+    'Tachikoma::Nodes::ClientConnector'       => q(clientconnector),
     'Tachikoma::Nodes::CommandInterpreter'    => q(),
     'Tachikoma::Nodes::Consumer'              => q(--partition=foo),
     'Tachikoma::Nodes::ConsumerBroker'        => q(--topic=foo),
@@ -121,85 +59,215 @@ my %nodes = (
     'Tachikoma::Nodes::FileReceiver'          => q(),
     'Tachikoma::Nodes::FileSender'            => q(),
     'Tachikoma::Nodes::FileWatcher'           => q(),
-    'Tachikoma::Nodes::Function'              => q({ return 1; }),
-    'Tachikoma::Nodes::Gate'                  => q(),
-    'Tachikoma::Nodes::Grep'                  => q(),
-    'Tachikoma::Nodes::Hopper'                => q(),
-    'Tachikoma::Nodes::HTTP_Auth'             => undef,
-    'Tachikoma::Nodes::HTTP_File'             => q(),
-    'Tachikoma::Nodes::HTTP_Fetch'            => q(),
-    'Tachikoma::Nodes::HTTP_Responder'        => q(),
-    'Tachikoma::Nodes::HTTP_Route'            => q(),
-    'Tachikoma::Nodes::HTTP_Store'            => q(),
-    'Tachikoma::Nodes::HTTP_Timeout'          => q(),
-    'Tachikoma::Nodes::Index'                 => q(),
-    'Tachikoma::Nodes::IndexByField'          => q(),
-    'Tachikoma::Nodes::IndexByStream'         => q(),
-    'Tachikoma::Nodes::IndexByTimestamp'      => q(),
-    'Tachikoma::Nodes::JobController'         => q(),
-    'Tachikoma::Nodes::JobFarmer'             => q(0 Echo),
-    'Tachikoma::Nodes::Join'                  => q(),
-    'Tachikoma::Nodes::List'                  => q(),
-    'Tachikoma::Nodes::LoadBalancer'          => q(),
-    'Tachikoma::Nodes::LoadController'        => q(),
-    'Tachikoma::Nodes::Log'                   => qq($t/log),
-    'Tachikoma::Nodes::LogPrefix'             => q(),
-    'Tachikoma::Nodes::Lookup'                => q(),
-    'Tachikoma::Nodes::LWP'                   => q(),
-    'Tachikoma::Nodes::MemorySieve'           => q(),
-    'Tachikoma::Nodes::Null'                  => q(),
-    'Tachikoma::Nodes::Number'                => q(),
-    'Tachikoma::Nodes::Partition'             => qq(--filename=$t/partition),
-    'Tachikoma::Nodes::PidWatcher'            => q(),
-    'Tachikoma::Nodes::QueryEngine'           => q(),
-    'Tachikoma::Nodes::Queue'                 => qq($t/queue.q),
-    'Tachikoma::Nodes::RandomSieve'           => q(),
-    'Tachikoma::Nodes::RateSieve'             => q(),
-    'Tachikoma::Nodes::Reducer'               => q(),
-    'Tachikoma::Nodes::RegexTee'              => q(),
-    'Tachikoma::Nodes::Responder'             => q(),
-    'Tachikoma::Nodes::Rewrite'               => q(),
-    'Tachikoma::Nodes::Ruleset'               => q(),
-    'Tachikoma::Nodes::Scheduler'             => qq($t/scheduler.db),
-    'Tachikoma::Nodes::SetStream'             => q(),
-    'Tachikoma::Nodes::SetType'               => q(),
-    'Tachikoma::Nodes::Shutdown'              => q(),
-    'Tachikoma::Nodes::Sieve'                 => q(),
-    'Tachikoma::Nodes::Split'                 => q(),
-    'Tachikoma::Nodes::StdErr'                => q(),
-    'Tachikoma::Nodes::Substr'                => q(),
-    'Tachikoma::Nodes::SudoFarmer'            => undef,
-    'Tachikoma::Nodes::Table'                 => q(),
-    'Tachikoma::Nodes::Tail'                  => q(/etc/hosts),
-    'Tachikoma::Nodes::Tee'                   => q(),
-    'Tachikoma::Nodes::TimedList'             => q(),
-    'Tachikoma::Nodes::Timeout'               => q(),
-    'Tachikoma::Nodes::Timer'                 => q(),
-    'Tachikoma::Nodes::Timestamp'             => q(),
-    'Tachikoma::Nodes::Topic'                 => q(),
-    'Tachikoma::Nodes::TopicProbe'            => q(1),
-    'Tachikoma::Nodes::Transform'             => q(- return 1;),
-    'Tachikoma::Nodes::Uniq'                  => q(),
-    'Tachikoma::Nodes::Watchdog'              => q(),
-    'Accessories::Nodes::ByteSplit'           => q(),
-    'Accessories::Nodes::HexDump'             => q(),
-    'Accessories::Nodes::IndexByHostname'     => q(),
-    'Accessories::Nodes::IndexByProcess'      => q(),
-    'Accessories::Nodes::Panel'               => undef,
-    'Accessories::Nodes::SFESerLCD'           => q(),
-    'Accessories::Nodes::SilentDeFlapper'     => q(),
-    'Accessories::Nodes::Smooth'              => q(),
+    'Tachikoma::Nodes::Function'          => q({ return <message.payload>; }),
+    'Tachikoma::Nodes::Gate'              => q(),
+    'Tachikoma::Nodes::Grep'              => q(),
+    'Tachikoma::Nodes::Hopper'            => q(),
+    'Tachikoma::Nodes::HTTP_Auth'         => undef,
+    'Tachikoma::Nodes::HTTP_File'         => q(),
+    'Tachikoma::Nodes::HTTP_Fetch'        => q(),
+    'Tachikoma::Nodes::HTTP_Responder'    => q(),
+    'Tachikoma::Nodes::HTTP_Route'        => q(),
+    'Tachikoma::Nodes::HTTP_Store'        => q(),
+    'Tachikoma::Nodes::HTTP_Timeout'      => q(),
+    'Tachikoma::Nodes::Index'             => q(),
+    'Tachikoma::Nodes::IndexByField'      => q(),
+    'Tachikoma::Nodes::IndexByStream'     => q(),
+    'Tachikoma::Nodes::IndexByTimestamp'  => q(),
+    'Tachikoma::Nodes::JobController'     => q(),
+    'Tachikoma::Nodes::JobFarmer'         => q(0 Echo),
+    'Tachikoma::Nodes::Join'              => q(),
+    'Tachikoma::Nodes::List'              => q(),
+    'Tachikoma::Nodes::LoadBalancer'      => q(),
+    'Tachikoma::Nodes::LoadController'    => q(),
+    'Tachikoma::Nodes::Log'               => qq($t/log),
+    'Tachikoma::Nodes::LogPrefix'         => q(),
+    'Tachikoma::Nodes::Lookup'            => q(),
+    'Tachikoma::Nodes::LWP'               => q(),
+    'Tachikoma::Nodes::MemorySieve'       => q(),
+    'Tachikoma::Nodes::Null'              => q(),
+    'Tachikoma::Nodes::Number'            => q(),
+    'Tachikoma::Nodes::Partition'         => qq(--filename=$t/partition),
+    'Tachikoma::Nodes::PidWatcher'        => q(),
+    'Tachikoma::Nodes::QueryEngine'       => q(),
+    'Tachikoma::Nodes::Queue'             => qq($t/queue.q),
+    'Tachikoma::Nodes::RandomSieve'       => q(),
+    'Tachikoma::Nodes::RateSieve'         => q(),
+    'Tachikoma::Nodes::Reducer'           => q(),
+    'Tachikoma::Nodes::RegexTee'          => q(),
+    'Tachikoma::Nodes::Responder'         => q(),
+    'Tachikoma::Nodes::Rewrite'           => q(),
+    'Tachikoma::Nodes::Ruleset'           => q(),
+    'Tachikoma::Nodes::Scheduler'         => qq($t/scheduler.db),
+    'Tachikoma::Nodes::SetStream'         => q(),
+    'Tachikoma::Nodes::SetType'           => q(),
+    'Tachikoma::Nodes::Shutdown'          => q(),
+    'Tachikoma::Nodes::Sieve'             => q(),
+    'Tachikoma::Nodes::Split'             => q(),
+    'Tachikoma::Nodes::StdErr'            => q(),
+    'Tachikoma::Nodes::Substr'            => q(),
+    'Tachikoma::Nodes::SudoFarmer'        => undef,
+    'Tachikoma::Nodes::Table'             => q(),
+    'Tachikoma::Nodes::Tail'              => q(/etc/hosts),
+    'Tachikoma::Nodes::Tee'               => q(),
+    'Tachikoma::Nodes::TimedList'         => q(),
+    'Tachikoma::Nodes::Timeout'           => q(),
+    'Tachikoma::Nodes::Timer'             => q(),
+    'Tachikoma::Nodes::Timestamp'         => q(),
+    'Tachikoma::Nodes::Topic'             => q(broker),
+    'Tachikoma::Nodes::TopicProbe'        => q(1),
+    'Tachikoma::Nodes::Transform'         => q(- return 1;),
+    'Tachikoma::Nodes::Uniq'              => q(),
+    'Tachikoma::Nodes::Watchdog'          => q(),
+    'Accessories::Nodes::ByteSplit'       => q(),
+    'Accessories::Nodes::HexDump'         => q(),
+    'Accessories::Nodes::IndexByHostname' => q(),
+    'Accessories::Nodes::IndexByProcess'  => q(),
+    'Accessories::Nodes::Panel'           => undef,
+    'Accessories::Nodes::SFESerLCD'       => q(),
+    'Accessories::Nodes::SilentDeFlapper' => q(),
+    'Accessories::Nodes::Smooth'          => q(),
 );
 
-# Tachikoma::Nodes::BufferTop
-# Tachikoma::Nodes::JSONtoStorable
-# Tachikoma::Nodes::SerialPort
-# Tachikoma::Nodes::Shell
-# Tachikoma::Nodes::Shell2
-# Tachikoma::Nodes::SQL
-# Tachikoma::Nodes::StorableToJSON
-# Tachikoma::Nodes::TopicTop
-# Accessories::Nodes::SFE4DigitLED
+my %skip_owner_test = (
+    'Tachikoma::Nodes::JobController' => 1,
+    'Tachikoma::Nodes::HTTP_Route'    => 1,
+    'Tachikoma::Nodes::LoadBalancer'  => 1,
+    'Tachikoma::Nodes::RegexTee'      => 1,
+    'Tachikoma::Nodes::Tee'           => 1,
+);
+
+my %skip_error_test = ( 'Tachikoma::Nodes::MemorySieve' => 1, );
+
+my %skip_eof_test = (
+    'Tachikoma::Nodes::FileReceiver' => 1,
+    'Tachikoma::Nodes::MemorySieve'  => 1,
+);
+
+my %skip_all_tests = (
+    'Tachikoma::Nodes::BufferTop'      => 1,
+    'Tachikoma::Nodes::JSONtoStorable' => 1,
+    'Tachikoma::Nodes::SerialPort'     => 1,
+    'Tachikoma::Nodes::Shell'          => 1,
+    'Tachikoma::Nodes::Shell2'         => 1,
+    'Tachikoma::Nodes::SQL'            => 1,
+    'Tachikoma::Nodes::StorableToJSON' => 1,
+    'Tachikoma::Nodes::TopicTop'       => 1,
+    'Accessories::Nodes::SFE4DigitLED' => 1,
+);
+
+my $router    = test_construction('Tachikoma::Nodes::Router');
+my $responder = test_construction('Tachikoma::Nodes::Responder');
+my $shell     = test_construction('Tachikoma::Nodes::Shell2');
+my $trap      = test_construction('Tachikoma::Nodes::Callback');
+
+$router->name('_router');
+$responder->name('_responder');
+$responder->shell($shell);
+
+my $taint = undef;
+{
+    local $/ = undef;
+    open my $fh, '<', '/dev/null' or die "couldn't open /dev/null: $!";
+    $taint = <$fh>;
+    close $fh or die "couldn't close /dev/null: $!";
+}
+
+$Tachikoma::Now       = time;
+$Tachikoma::Right_Now = time;
+
+sub test_node {
+    my $node      = shift;
+    my $test_args = shift;
+    my $class     = ref $node;
+    my $name      = lc $class;
+    $name =~ s{.*:}{};
+    is( $node->name($name),       $name, "$class->name can be set" );
+    is( $node->name,              $name, "$class->name is set correctly" );
+    is( $Tachikoma::Nodes{$name}, $node, "$class->name is ok" );
+    if ( defined $test_args ) {
+        $test_args .= $taint;
+        is( $node->arguments($test_args),
+            $test_args, "$class->arguments can be set" );
+        is( $node->arguments, $test_args,
+            "$class->arguments are set correctly" );
+        is( $node->sink($trap), $trap, "$class->sink can be set" );
+        is( $node->sink,        $trap, "$class->sink is set correctly" );
+        if ( not $skip_owner_test{$class} ) {
+            is( $node->owner('foo'), 'foo', "$class->owner can be set" );
+            is( $node->owner, 'foo', "$class->owner is set correctly" );
+        }
+        test_fire( $class, $node );
+        test_fill_error( $class, $node ) if ( not $skip_error_test{$class} );
+        test_fill_eof( $class, $node ) if ( not $skip_eof_test{$class} );
+    }
+    is( $node->remove_node, undef, "$class->remove_node returns undef" );
+    while ( my $close_cb = shift @Tachikoma::Closing ) {
+        &{$close_cb}();
+    }
+    is( $Tachikoma::Nodes{$name}, undef, "$class->remove_node is ok" );
+    return;
+}
+
+sub test_fire {
+    my $class = shift;
+    my $node  = shift;
+    if ( $node->can('fire') ) {
+        $trap->callback( sub {return} );
+        $Tachikoma::Now       = time;
+        $Tachikoma::Right_Now = time;
+        is( $node->fire, undef, "$class->fire returns undef" );
+    }
+    return;
+}
+
+sub test_fill_error {
+    my $class = shift;
+    my $node  = shift;
+    $trap->callback(
+        sub {
+            my $message = shift;
+            is( $message->from, $class,
+                "$class->fill does not stamp TM_ERROR" );
+            my %valid = ( $class => 1, 'foo' => 1, q() => 1 );
+            my $okay = $valid{ $message->to };
+            is( $okay, 1, "$class->fill routes TM_ERROR correctly" );
+            is( $message->payload, "NOT_AVAILABLE\n",
+                "$class->fill does not rewrite TM_ERROR" );
+            return;
+        }
+    );
+    my $message = Tachikoma::Message->new;
+    $message->type(TM_ERROR);
+    $message->from($class);
+    $message->payload( "NOT_AVAILABLE\n" . $taint );
+    is( $node->fill($message), undef, "$class->fill TM_ERROR returns undef" );
+    return;
+}
+
+sub test_fill_eof {
+    my $class = shift;
+    my $node  = shift;
+    $trap->callback(
+        sub {
+            my $message = shift;
+            is( $message->from, $class,
+                "$class->fill does not stamp TM_EOF" );
+            my %valid = ( $class => 1, 'foo' => 1, q() => 1 );
+            my $okay = $valid{ $message->to };
+            is( $okay, 1, "$class->fill routes TM_EOF correctly" );
+            is( $message->payload, q(),
+                "$class->fill does not rewrite TM_EOF" );
+            return;
+        }
+    );
+    my $message = Tachikoma::Message->new;
+    $message->type(TM_EOF);
+    $message->from($class);
+    $message->payload($taint);
+    is( $node->fill($message), undef, "$class->fill TM_EOF returns undef" );
+    return;
+}
 
 for my $class ( sort keys %nodes ) {
     test_node( test_construction($class), $nodes{$class} );

--- a/t/shell.t
+++ b/t/shell.t
@@ -7,7 +7,7 @@
 #
 use strict;
 use warnings;
-use Test::More tests => 78;
+use Test::More tests => 77;
 
 use Tachikoma;
 use Tachikoma::Nodes::Shell2;
@@ -23,12 +23,12 @@ $Data::Dumper::Useperl  = 1;
 
 #####################################################################
 my $shell = Tachikoma::Nodes::Shell2->new;
-is( ref $shell, 'Tachikoma::Nodes::Shell2', 'Shell2::new()' );
+is( ref $shell, 'Tachikoma::Nodes::Shell2', 'Shell2->new is ok' );
 
 # callback->new
 my $answer;
 my $destination = Tachikoma::Nodes::Callback->new;
-is( ref $destination, 'Tachikoma::Nodes::Callback', 'Callback::new()' );
+is( ref $destination, 'Tachikoma::Nodes::Callback', 'Callback->new is ok' );
 $shell->sink($destination);
 $destination->callback(
     sub {
@@ -137,14 +137,9 @@ is( $Var{bar}, 13, 'variable iteration sets variables correctly' );
 $parse_tree = $shell->parse('send echo (2 - -1)');
 $answer     = q();
 $shell->send_command($parse_tree);
-is( $answer, "{3}\n", 'math operators 1' );
-
-#####################################################################
-
 $parse_tree = $shell->parse('send echo (-2 + 1)');
-$answer     = q();
 $shell->send_command($parse_tree);
-is( $answer, "{-1}\n", 'math operators 2' );
+is( $answer, "{3}\n{-1}\n", 'arithmetic operators are evaluated correctly' );
 
 #####################################################################
 


### PR DESCRIPTION
New, portable FileWatcher node to replace Watcher in TailForks job.
Test fill methods with TM_EOF.
Test fire methods.
More error cleanups.
Better examples.
Other cleanups.