### PR TITLE
Cleanup handling of acknowledgements.

### DIFF
--- a/lib/Accessories/Jobs/Lucky.pm
+++ b/lib/Accessories/Jobs/Lucky.pm
@@ -39,7 +39,7 @@ sub initialize_graph {
 sub fill {
     my $self    = shift;
     my $message = shift;
-    if ( $message->to ) {
+    if ( length $message->to ) {
         if ( $message->type & TM_EOF ) {
             my $html = $self->collector;
             my $out  = '';

--- a/lib/Accessories/Nodes/Spool.pm
+++ b/lib/Accessories/Nodes/Spool.pm
@@ -67,7 +67,7 @@ sub fill {
         if ( $message->[PAYLOAD] eq 'cancel' ) {
             my $path = join q(/), $self->{spool_dir}, $message->[STREAM];
             unlink $path
-                or $self->stderr("ERROR: couldn't unlink $path: $!");
+                or return $self->stderr("ERROR: couldn't unlink $path: $!");
             $self->stop_timer;
             $self->set_timer(0);
         }

--- a/lib/Accessories/Nodes/Spool.pm
+++ b/lib/Accessories/Nodes/Spool.pm
@@ -70,8 +70,12 @@ sub fill {
                 or return $self->stderr("ERROR: couldn't unlink $path: $!");
             $self->stop_timer;
             $self->set_timer(0);
+            delete $self->{spool}->{ $message->[STREAM] };
         }
-        delete $self->{spool}->{ $message->[STREAM] };
+        else {
+            $self->stderr( 'WARNING: unexpected answer from ',
+                $message->[FROM] );
+        }
     }
     elsif ( $message->[TYPE] & TM_ERROR ) {
         delete $self->{spool}->{ $message->[STREAM] };

--- a/lib/Tachikoma.pm
+++ b/lib/Tachikoma.pm
@@ -3,7 +3,7 @@
 # Tachikoma
 # ----------------------------------------------------------------------
 #
-# $Id: Tachikoma.pm 35488 2018-10-21 15:03:01Z chris $
+# $Id: Tachikoma.pm 35592 2018-10-24 03:55:04Z chris $
 #
 
 package Tachikoma;
@@ -152,7 +152,6 @@ sub new {
     $self->{auth_challenge} = undef;
     $self->{auth_timestamp} = undef;
     $self->{input_buffer}   = \$input_buffer;
-    $self->{persist}        = 'cancel';
     $self->{timeout}        = DEFAULT_TIMEOUT;
     bless $self, $class;
     return $self;
@@ -411,7 +410,6 @@ sub reconnect {
         }
     } while ( not $tachikoma );
     if ( ref $self ) {
-        $tachikoma->persist( $self->{persist} );
         $tachikoma->timeout( $self->{timeout} );
     }
     return $tachikoma;
@@ -712,14 +710,6 @@ sub input_buffer {
         $self->{input_buffer} = shift;
     }
     return $self->{input_buffer};
-}
-
-sub persist {
-    my $self = shift;
-    if (@_) {
-        $self->{persist} = shift;
-    }
-    return $self->{persist};
 }
 
 sub timeout {

--- a/lib/Tachikoma/Job.pm
+++ b/lib/Tachikoma/Job.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Job
 # ----------------------------------------------------------------------
 #
-# $Id: Job.pm 35477 2018-10-21 13:27:41Z chris $
+# $Id: Job.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Job;
@@ -292,7 +292,7 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     my $rv      = undef;
-    $message->[TO] = '_parent' if ( not $message->[TO] );
+    $message->[TO] = '_parent' if ( not length $message->[TO] );
     $self->{counter}++;
     $rv = $self->{router}->fill($message)
         if ( not $message->[TYPE] & TM_EOF

--- a/lib/Tachikoma/Jobs/Inet_AtoN.pm
+++ b/lib/Tachikoma/Jobs/Inet_AtoN.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Jobs::Inet_AtoN
 # ----------------------------------------------------------------------
 #
-# $Id: Inet_AtoN.pm 35265 2018-10-16 06:42:47Z chris $
+# $Id: Inet_AtoN.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Jobs::Inet_AtoN;
@@ -83,7 +83,7 @@ sub fill {
             die $@ if ( $@ ne "alarm\n" );    # propagate unexpected errors
         }
     }
-    $message->[TO]      = $message->[FROM] if ( not $message->[TO] );
+    $message->[TO]      = $message->[FROM];
     $message->[FROM]    = q();
     $message->[PAYLOAD] = $number ? join q(), inet_ntoa($number), "\n" : q();
     return $self->SUPER::fill($message);

--- a/lib/Tachikoma/Jobs/TailForks.pm
+++ b/lib/Tachikoma/Jobs/TailForks.pm
@@ -168,7 +168,7 @@ sub fill {
     }
     elsif ( $message->[FROM] =~ m{^(.*):tail$} ) {
         my $file = $1;
-        return $self->{sink}->fill($message) if ( $message->[TO] );
+        return $self->{sink}->fill($message) if ( length $message->[TO] );
         my $forking = $self->{forking};
         $self->position( $file, $message->[ID] ) if ( $message->[ID] );
         $message->[STREAM] = $file;

--- a/lib/Tachikoma/Node.pm
+++ b/lib/Tachikoma/Node.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Node
 # ----------------------------------------------------------------------
 #
-# $Id: Node.pm 35327 2018-10-17 04:54:45Z chris $
+# $Id: Node.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Node;
@@ -48,7 +48,7 @@ sub name {
             if ( exists $nodes->{$name} );
 
         # support renaming
-        delete $nodes->{ $self->{name} } if ( $self->{name} );
+        delete $nodes->{ $self->{name} } if ( length $self->{name} );
         $self->{name} = $name;
         $nodes->{$name} = $self if ( length $name );
     }
@@ -65,7 +65,7 @@ sub arguments {
 
 sub fill {
     my ( $self, $message ) = @_;
-    $message->[TO] ||= $self->{owner};
+    $message->[TO] = $self->{owner} if ( not length $message->[TO] );
     $self->{counter}++;
     return $self->{sink}->fill($message);
 }
@@ -135,7 +135,7 @@ sub unregister {
 
 sub connect_node {
     my ( $self, $name, $owner ) = @_;
-    die "no node specified\n" if ( not $name );
+    die "no node specified\n" if ( not length $name );
     my $node = Tachikoma->nodes->{$name};
     die qq(no such node: "$name"\n) if ( not $node );
     if ( ref( $node->owner ) eq 'ARRAY' ) {

--- a/lib/Tachikoma/Nodes/Buffer.pm
+++ b/lib/Tachikoma/Nodes/Buffer.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::Buffer
 # ----------------------------------------------------------------------
 #
-# $Id: Buffer.pm 35420 2018-10-20 09:48:46Z chris $
+# $Id: Buffer.pm 35592 2018-10-24 03:55:04Z chris $
 #
 
 package Tachikoma::Nodes::Buffer;
@@ -98,7 +98,6 @@ sub fill {
     my $unanswered     = keys %{ $self->{msg_unanswered} };
     my $max_unanswered = $self->{max_unanswered};
     my $buffer_size    = $self->{buffer_size} // $self->get_buffer_size;
-    my $buffer_mode    = $self->{buffer_mode};
     my $copy           = bless [ @{$message} ], ref $message;
     $self->set_timer(0)
         if ( $self->{owner} and $unanswered < $max_unanswered );
@@ -108,7 +107,7 @@ sub fill {
         and not $type & TM_STORABLE
         and not $type & TM_INFO );
     $self->{counter}++;
-    return if ( $buffer_mode eq 'null' );
+    return if ( $self->{buffer_mode} eq 'null' );
     do {
         $message_id = $self->msg_counter;
     } while ( exists $tiedhash->{$message_id} );

--- a/lib/Tachikoma/Nodes/CommandInterpreter.pm
+++ b/lib/Tachikoma/Nodes/CommandInterpreter.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::CommandInterpreter
 # ----------------------------------------------------------------------
 #
-# $Id: CommandInterpreter.pm 35587 2018-10-24 02:49:28Z chris $
+# $Id: CommandInterpreter.pm 35607 2018-10-24 17:12:33Z chris $
 #
 
 package Tachikoma::Nodes::CommandInterpreter;
@@ -1390,7 +1390,7 @@ $C{slurp_file} = sub {
     my $self        = shift;
     my $command     = shift;
     my $envelope    = shift;
-    my $buffer_mode = shift;
+    my $buffer_mode = shift // 'binary';
     $self->verify_key( $envelope, ['meta'], 'slurp' )
         or return $self->error("verification failed\n");
     my ( $path, $edge_name ) = split q( ), $command->arguments, 2;

--- a/lib/Tachikoma/Nodes/CommandInterpreter.pm
+++ b/lib/Tachikoma/Nodes/CommandInterpreter.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::CommandInterpreter
 # ----------------------------------------------------------------------
 #
-# $Id: CommandInterpreter.pm 35585 2018-10-24 02:44:55Z chris $
+# $Id: CommandInterpreter.pm 35587 2018-10-24 02:49:28Z chris $
 #
 
 package Tachikoma::Nodes::CommandInterpreter;
@@ -1307,7 +1307,7 @@ $C{connect_node} = sub {
     $self->verify_key( $envelope, ['meta'], 'connect_node' )
         or return $self->error("verification failed\n");
     my ( $name, $owner ) = split q( ), $command->arguments, 2;
-    $owner = $envelope->from if ( not length $envelope->from );
+    $owner = $envelope->from if ( not length $owner );
     $self->connect_node( $name, $owner );
     return $self->okay($envelope);
 };

--- a/lib/Tachikoma/Nodes/Consumer.pm
+++ b/lib/Tachikoma/Nodes/Consumer.pm
@@ -158,8 +158,6 @@ sub fill {    ## no critic (ProhibitExcessComplexity)
     my ( $offset, $next_offset ) = split m{:}, $message->[ID], 2;
     if ( $message->[TYPE] == ( TM_PERSIST | TM_RESPONSE ) ) {
         if ( $message->[PAYLOAD] eq 'answer' ) {
-            $self->stderr( 'WARNING: unexpected answer from ',
-                $message->[FROM] );
             $self->remove_node if ( defined $self->partition_id );
         }
         elsif ( $self->{timestamps}->{$offset} ) {

--- a/lib/Tachikoma/Nodes/ConsumerBroker.pm
+++ b/lib/Tachikoma/Nodes/ConsumerBroker.pm
@@ -56,7 +56,6 @@ sub new {
     $self->{broker_ids}  = undef;
     $self->{hub_timeout} = $Default_Hub_Timeout;
     $self->{targets}     = {};
-    $self->{persist}     = 'cancel';
     $self->{partitions}  = undef;
     $self->{leader}      = undef;
     $self->{last_check}  = 0;
@@ -797,11 +796,6 @@ sub hosts {
 sub broker_ids {
     my (@args) = @_;
     return Tachikoma::Nodes::Topic::broker_ids(@args);
-}
-
-sub persist {
-    my (@args) = @_;
-    return Tachikoma::Nodes::Topic::persist(@args);
 }
 
 sub hub_timeout {

--- a/lib/Tachikoma/Nodes/FileHandle.pm
+++ b/lib/Tachikoma/Nodes/FileHandle.pm
@@ -6,7 +6,7 @@
 # Tachikomatic IPC - send and receive messages over filehandles
 #                  - on_EOF: close, send, ignore
 #
-# $Id: FileHandle.pm 35585 2018-10-24 02:44:55Z chris $
+# $Id: FileHandle.pm 35595 2018-10-24 05:06:45Z chris $
 #
 
 package Tachikoma::Nodes::FileHandle;
@@ -58,6 +58,7 @@ sub new {
     $self->{flags}            = $flags;
     $self->{on_EOF}           = 'close';
     $self->{drain_fh}         = \&drain_fh;
+    $self->{drain_buffer}     = \&drain_buffer_normal;
     $self->{fill_fh}          = \&fill_fh;
     $self->{input_buffer}     = \$input_buffer;
     $self->{output_buffer}    = [];
@@ -71,9 +72,7 @@ sub new {
     $self->{largest_msg_sent} = 0;
     $self->{fill_modes}       = {
         null => \&null_cb,
-        fill => $flags & TK_SYNC
-        ? \&fill_fh_sync
-        : \&fill_buffer
+        fill => $flags & TK_SYNC ? \&fill_fh_sync : \&fill_buffer
     };
     $self->{fill} = $self->{fill_modes}->{fill};
     bless $self, $class;
@@ -137,7 +136,7 @@ sub drain_fh {
         return $self->handle_EOF;
     }
     $got += $read;
-    $got = $self->drain_buffer($buffer) if ( $got > 0 );
+    $got = &{ $self->{drain_buffer} }( $self, $buffer ) if ( $got > 0 );
     if ( not defined $got or $got < 1 ) {
         my $new_buffer = q();
         $self->{input_buffer} = \$new_buffer;
@@ -145,7 +144,7 @@ sub drain_fh {
     return $read;
 }
 
-sub drain_buffer {
+sub drain_buffer_normal {
     my $self   = shift;
     my $buffer = shift;
     my $name   = $self->{name};

--- a/lib/Tachikoma/Nodes/FileHandle.pm
+++ b/lib/Tachikoma/Nodes/FileHandle.pm
@@ -6,7 +6,7 @@
 # Tachikomatic IPC - send and receive messages over filehandles
 #                  - on_EOF: close, send, ignore
 #
-# $Id: FileHandle.pm 35512 2018-10-22 08:27:21Z chris $
+# $Id: FileHandle.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::FileHandle;
@@ -176,7 +176,7 @@ sub drain_buffer {
             length $message->[FROM]
             ? join q(/), $name, $message->[FROM]
             : $name;
-        if ( $message->[TO] and $owner ) {
+        if ( length $message->[TO] and length $owner ) {
             $self->print_less_often(
                       "ERROR: message addressed to $message->[TO]"
                     . " while owner is set to $owner"
@@ -184,7 +184,7 @@ sub drain_buffer {
                 if ( $message->[TYPE] != TM_ERROR );
             next;
         }
-        $message->[TO] = $owner if ($owner);
+        $message->[TO] = $owner if ( length $owner );
         $sink->fill($message);
     }
     return $got;

--- a/lib/Tachikoma/Nodes/FileSender.pm
+++ b/lib/Tachikoma/Nodes/FileSender.pm
@@ -99,7 +99,7 @@ sub fill {    ## no critic (ProhibitExcessComplexity)
     }
 
     # service tee
-    return $self->{sink}->fill($message) if ( $message->[TO] );
+    return $self->{sink}->fill($message) if ( length $message->[TO] );
 
     # make sure it's a bytestream and has what we're looking for
     return if ( not $type & TM_BYTESTREAM );

--- a/lib/Tachikoma/Nodes/JobFarmer.pm
+++ b/lib/Tachikoma/Nodes/JobFarmer.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::JobFarmer
 # ----------------------------------------------------------------------
 #
-# $Id: JobFarmer.pm 35293 2018-10-16 20:32:45Z chris $
+# $Id: JobFarmer.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::JobFarmer;
@@ -118,7 +118,7 @@ sub fill {
         else {
             $message->[FROM] = $from if ( $next and $next eq '_parent' );
         }
-        $message->[TO] ||= $self->{owner};
+        $message->[TO] = $self->{owner} if ( not length $message->[TO] );
         $self->{sink}->fill($message);
     }
     else {

--- a/lib/Tachikoma/Nodes/Log.pm
+++ b/lib/Tachikoma/Nodes/Log.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::Log
 # ----------------------------------------------------------------------
 #
-# $Id: Log.pm 35477 2018-10-21 13:27:41Z chris $
+# $Id: Log.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::Log;
@@ -80,7 +80,7 @@ sub fill {
         }
         return;
     }
-    elsif ( not $message->[FROM] and $message->[STREAM] eq 'utimer' ) {
+    elsif ( not length $message->[FROM] and $message->[STREAM] eq 'utimer' ) {
         utime $Tachikoma::Now, $Tachikoma::Now, $self->{filename}
             or $self->stderr("ERROR: couldn't utime $self->{filename}: $!");
         return;

--- a/lib/Tachikoma/Nodes/Lookup.pm
+++ b/lib/Tachikoma/Nodes/Lookup.pm
@@ -32,7 +32,7 @@ sub fill {
         defined $self->{edge}->lookup( $message->[STREAM] )
         ? $self->{owner}
         : $self->{arguments};
-    if ( $message->[TO] ) {
+    if ( length $message->[TO] ) {
         $self->{sink}->fill($message);
     }
     else {

--- a/lib/Tachikoma/Nodes/Partition.pm
+++ b/lib/Tachikoma/Nodes/Partition.pm
@@ -195,7 +195,7 @@ sub fill {    ## no critic (ProhibitExcessComplexity)
         }
         return;
     }
-    elsif ( $message->[TO] ) {
+    elsif ( length $message->[TO] ) {
         $self->stderr( 'ERROR: message addressed to ', $message->[TO] );
         return;
     }

--- a/lib/Tachikoma/Nodes/Queue.pm
+++ b/lib/Tachikoma/Nodes/Queue.pm
@@ -79,7 +79,6 @@ sub fill {
     my $unanswered     = keys %{ $self->{msg_unanswered} };
     my $max_unanswered = $self->{max_unanswered};
     my $buffer_size    = $self->{buffer_size} // $self->get_buffer_size;
-    my $buffer_mode    = $self->{buffer_mode};
     my $copy           = bless [ @{$message} ], ref $message;
     $self->set_timer(0)
         if ( $self->{owner} and $unanswered < $max_unanswered );
@@ -89,7 +88,7 @@ sub fill {
         and not $type & TM_STORABLE
         and not $type & TM_INFO );
     $self->{counter}++;
-    return if ( $buffer_mode eq 'null' );
+    return if ( $self->{buffer_mode} eq 'null' );
     my $sth = $dbh->prepare('SELECT count(1) FROM queue WHERE message_id=?');
     do {
         $message_id = $self->msg_counter;

--- a/lib/Tachikoma/Nodes/Router.pm
+++ b/lib/Tachikoma/Nodes/Router.pm
@@ -84,17 +84,16 @@ sub fill {
     return $self->drop_message( $message, 'path exceeded 1024 bytes' )
         if ( ( length $message->[FROM] // 0 ) > 1024 );
     my ( $name, $path ) = split m{/}, $message->[TO], 2;
-    my $node = $Tachikoma::Nodes{$name};
-    return $self->send_error( $message, "NOT_AVAILABLE\n" ) if ( not $node );
+    return $self->send_error( $message, "NOT_AVAILABLE\n" )
+        if ( not $Tachikoma::Nodes{$name} );
     $message->[TO] = $path;
-
     if ($Tachikoma::Profiles) {
         my $before = $self->push_profile($name);
-        my $rv     = $node->fill($message);
+        my $rv     = $Tachikoma::Nodes{$name}->fill($message);
         $self->pop_profile($before);
         return $rv;
     }
-    return $node->fill($message);
+    return $Tachikoma::Nodes{$name}->fill($message);
 }
 
 sub send_error {

--- a/lib/Tachikoma/Nodes/SQL.pm
+++ b/lib/Tachikoma/Nodes/SQL.pm
@@ -62,7 +62,7 @@ sub fill {
                 $dbh->errstr, "\n" );
             return;
         }
-        if ( $message->[TO] ) {
+        if ( length $message->[TO] ) {
             $self->respond(
                 $message,
                 TM_INFO,

--- a/lib/Tachikoma/Nodes/STDIO.pm
+++ b/lib/Tachikoma/Nodes/STDIO.pm
@@ -10,7 +10,7 @@
 #   - on_EOF: close, send, ignore, reconnect,
 #             wait_to_send, wait_to_close
 #
-# $Id: STDIO.pm 35512 2018-10-22 08:27:21Z chris $
+# $Id: STDIO.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::STDIO;
@@ -271,7 +271,9 @@ sub fill {
         $self->{got_EOF} = 'true';
         $self->handle_EOF if ( not @{ $self->{output_buffer} } );
     }
-    elsif ( not $message->[FROM] and $message->[STREAM] eq 'msg_timer' ) {
+    elsif ( not length $message->[FROM]
+        and $message->[STREAM] eq 'msg_timer' )
+    {
         if ( $self->{on_timeout} eq 'close' ) {
             $self->stderr('WARNING: timeout waiting for response');
             $self->remove_node;

--- a/lib/Tachikoma/Nodes/STDIO.pm
+++ b/lib/Tachikoma/Nodes/STDIO.pm
@@ -10,7 +10,7 @@
 #   - on_EOF: close, send, ignore, reconnect,
 #             wait_to_send, wait_to_close
 #
-# $Id: STDIO.pm 35595 2018-10-24 05:06:45Z chris $
+# $Id: STDIO.pm 35610 2018-10-24 17:15:29Z chris $
 #
 
 package Tachikoma::Nodes::STDIO;
@@ -477,6 +477,7 @@ sub buffer_mode {
     my $self = shift;
     if (@_) {
         $self->{buffer_mode} = shift;
+        $self->set_drain_buffer;
     }
     return $self->{buffer_mode};
 }

--- a/lib/Tachikoma/Nodes/Scheduler.pm
+++ b/lib/Tachikoma/Nodes/Scheduler.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::Scheduler
 # ----------------------------------------------------------------------
 #
-# $Id: Scheduler.pm 35568 2018-10-23 08:56:20Z chris $
+# $Id: Scheduler.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::Scheduler;
@@ -102,7 +102,7 @@ sub fire {
             }
             $message->[FROM] = $self->{owner}
                 if ( not $Tachikoma::Nodes{$name} );
-            $message->[TYPE] |= TM_NOREPLY if ( not $message->[FROM] );
+            $message->[TYPE] |= TM_NOREPLY if ( not length $message->[FROM] );
             $message->[TIMESTAMP] = $Tachikoma::Now;
             $command->sign( $self->scheme, $Tachikoma::Now );
             $message->payload( $command->packed );

--- a/lib/Tachikoma/Nodes/SerialPort.pm
+++ b/lib/Tachikoma/Nodes/SerialPort.pm
@@ -3,7 +3,7 @@
 # Tachikoma::Nodes::SerialPort
 # ----------------------------------------------------------------------
 #
-# $Id: SerialPort.pm 35512 2018-10-22 08:27:21Z chris $
+# $Id: SerialPort.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::SerialPort;
@@ -108,7 +108,9 @@ sub fill {
     if ( $message->[TYPE] & TM_COMMAND or $message->[TYPE] & TM_EOF ) {
         return $self->interpreter->fill($message);
     }
-    elsif ( not $message->[FROM] and $message->[STREAM] eq 'wait_timer' ) {
+    elsif ( not length $message->[FROM]
+        and $message->[STREAM] eq 'wait_timer' )
+    {
         $self->register_reader_node;
         $self->{waiting} = undef;
         return;

--- a/lib/Tachikoma/Nodes/SetStream.pm
+++ b/lib/Tachikoma/Nodes/SetStream.pm
@@ -46,13 +46,13 @@ sub fill {
     my $self    = shift;
     my $message = shift;
     my $regex   = $self->{regex};
-    if ( $message->[TYPE] & TM_BYTESTREAM ) {
-        if ( $self->{force} ) {
-            $message->[STREAM] = $self->{force};
-        }
-        elsif ( $message->[PAYLOAD] =~ m{$regex} ) {
-            $message->[STREAM] = md5_hex($1);
-        }
+    if ( $self->{force} ) {
+        $message->[STREAM] = $self->{force};
+    }
+    elsif ( $message->[TYPE] & TM_BYTESTREAM
+        and $message->[PAYLOAD] =~ m{$regex} )
+    {
+        $message->[STREAM] = md5_hex($1);
     }
     return $self->SUPER::fill($message);
 }

--- a/lib/Tachikoma/Nodes/Shell2.pm
+++ b/lib/Tachikoma/Nodes/Shell2.pm
@@ -392,7 +392,7 @@ sub dequote {
         ${$value} =~ s{\\([^<\w>])}{$1}g;
     }
     elsif ( $type eq 'string2' ) {
-        ${$value} =~ s{\\(')}{$1}g;
+        ${$value} =~ s{\\([\\'])}{$1}g;
     }
     elsif ( $type eq 'string4' ) {
         ${$value} =~ s{^\\}{};

--- a/lib/Tachikoma/Nodes/Socket.pm
+++ b/lib/Tachikoma/Nodes/Socket.pm
@@ -238,6 +238,7 @@ sub new {
     $self->{scheme}           = Tachikoma->scheme;
     $self->{delegates}        = {};
     $self->{drain_fh}         = \&Tachikoma::Nodes::FileHandle::drain_fh;
+    $self->{drain_buffer}     = \&drain_buffer_normal;
     $self->{fill_fh}          = \&Tachikoma::Nodes::FileHandle::fill_fh;
     $self->{last_upbeat}      = undef;
     $self->{last_downbeat}    = undef;
@@ -347,8 +348,9 @@ sub accept_connection {
     $node->{fill}           = $node->{fill_modes}->{unauthenticated};
     $node->{max_unanswered} = $self->{max_unanswered}
         if ( exists $self->{max_unanswered} );
-    $node->buffer_mode( $self->{buffer_mode} )
+    $node->{buffer_mode} = $self->{buffer_mode}
         if ( exists $self->{buffer_mode} );
+    $node->set_drain_buffer;
 
     for my $event ( keys %{ $self->{registrations} } ) {
         my $r = $self->{registrations}->{$event};
@@ -611,7 +613,7 @@ sub reply_to_client_challenge {
     $self->notify( 'authenticated' => $self->{name} );
     unshift @{ $self->{output_buffer} }, $message->packed;
     $self->register_writer_node;
-    $self->drain_buffer( $self->{input_buffer} ) if ( $got > 0 );
+    &{ $self->{drain_buffer} }( $self, $self->{input_buffer} ) if ($got);
     return;
 }
 
@@ -622,7 +624,7 @@ sub auth_server_response {
         \&Tachikoma::Nodes::FileHandle::drain_fh,
         \&Tachikoma::Nodes::FileHandle::fill_fh
     );
-    $self->drain_buffer( $self->{input_buffer} ) if ($got);
+    &{ $self->{drain_buffer} }( $self, $self->{input_buffer} ) if ($got);
     return;
 }
 
@@ -793,17 +795,11 @@ sub delegate_authorization {
     return $allowed;
 }
 
-sub do_not_enter {
-    my $self = shift;
-    return $self->stderr('ERROR: not yet authenticated - message discarded');
-}
-
-sub drain_buffer {
+sub drain_buffer_normal {
     my $self   = shift;
     my $buffer = shift;
     my $name   = $self->{name};
     my $sink   = $self->{sink};
-    my $edge   = $self->{edge};
     my $owner  = $self->{owner};
     my $got    = length ${$buffer};
 
@@ -848,6 +844,28 @@ sub drain_buffer {
     return $got;
 }
 
+sub drain_buffer_edge {
+    my $self   = shift;
+    my $buffer = shift;
+    my $name   = $self->{name};
+    my $edge   = $self->{edge};
+    my $got    = length ${$buffer};
+    my $size   = $got > VECTOR_SIZE ? unpack 'N', ${$buffer} : 0;
+    while ( $got >= $size and $size > 0 ) {
+        my $message =
+            Tachikoma::Message->new( \substr ${$buffer}, 0, $size, q() );
+        $got -= $size;
+        $self->{bytes_read} += $size;
+        $size = $got > VECTOR_SIZE ? unpack 'N', ${$buffer} : 0;
+        if ( $message->[TYPE] & TM_HEARTBEAT ) {
+            $self->reply_to_heartbeat($message);
+            next;
+        }
+        $edge->activate( \$message->[PAYLOAD] );
+    }
+    return $got;
+}
+
 sub reply_to_heartbeat {
     my $self    = shift;
     my $message = shift;
@@ -877,6 +895,11 @@ sub reply_to_heartbeat {
         }
     }
     return;
+}
+
+sub do_not_enter {
+    my $self = shift;
+    return $self->stderr('ERROR: not yet authenticated - message discarded');
 }
 
 sub fill_buffer_init {
@@ -1130,6 +1153,22 @@ sub dump_config {    ## no critic (ProhibitExcessComplexity)
         $response = $self->SUPER::dump_config;
     }
     return $response;
+}
+
+sub edge {
+    my $self = shift;
+    if (@_) {
+        $self->{edge} = shift;
+        $self->set_drain_buffer;
+    }
+    return $self->{edge};
+}
+
+sub set_drain_buffer {
+    my $self = shift;
+    $self->{drain_buffer} =
+        $self->{edge} ? \&drain_buffer_edge : \&drain_buffer_normal;
+    return;
 }
 
 sub hostname {

--- a/lib/Tachikoma/Nodes/Socket.pm
+++ b/lib/Tachikoma/Nodes/Socket.pm
@@ -830,15 +830,11 @@ sub drain_buffer {
             $self->reply_to_heartbeat($message);
             next;
         }
-        elsif ($edge) {
-            $edge->activate( $message->[PAYLOAD] );
-            next;
-        }
         $message->[FROM] =
             length $message->[FROM]
             ? join q(/), $name, $message->[FROM]
             : $name;
-        if ( $message->[TO] and $owner ) {
+        if ( length $message->[TO] and length $owner ) {
             $self->print_less_often(
                       "ERROR: message addressed to $message->[TO]"
                     . " while owner is set to $owner"
@@ -846,7 +842,7 @@ sub drain_buffer {
                 if ( $message->[TYPE] != TM_ERROR );
             next;
         }
-        $message->[TO] = $owner if ($owner);
+        $message->[TO] = $owner if ( length $owner );
         $sink->fill($message);
     }
     return $got;

--- a/lib/Tachikoma/Nodes/TTY.pm
+++ b/lib/Tachikoma/Nodes/TTY.pm
@@ -5,7 +5,7 @@
 #
 # Tachikoma::Nodes::STDIO plus Readline support
 #
-# $Id: TTY.pm 35327 2018-10-17 04:54:45Z chris $
+# $Id: TTY.pm 35585 2018-10-24 02:44:55Z chris $
 #
 
 package Tachikoma::Nodes::TTY;
@@ -32,7 +32,7 @@ sub new {
     $self->{term}         = undef;
     $self->{prompt}       = undef;
     $self->{width}        = undef;
-    $self->{completions}  = {};
+    $self->{completions}  = { 'help' => [], 'ls' => [] };
     $self->{queue}        = [];
     $self->{readline_EOF} = undef;
     bless $self, $class;

--- a/lib/Tachikoma/Nodes/Tail.pm
+++ b/lib/Tachikoma/Nodes/Tail.pm
@@ -7,7 +7,7 @@
 #             wait_to_send, wait_to_close, wait_to_delete,
 #             wait_for_delete, wait_for_a_while
 #
-# $Id: Tail.pm 35477 2018-10-21 13:27:41Z chris $
+# $Id: Tail.pm 35592 2018-10-24 03:55:04Z chris $
 #
 
 package Tachikoma::Nodes::Tail;
@@ -212,7 +212,8 @@ sub fill {
         and not $message->[TYPE] & TM_EOF );
     return
         if ( not $max_unanswered
-        or $message->[TYPE] != ( TM_PERSIST | TM_RESPONSE ) );
+        or $message->[TYPE] != ( TM_PERSIST | TM_RESPONSE )
+        or $message->[PAYLOAD] ne 'cancel' );
     $self->{bytes_answered} = $message->[ID]
         if ($message->[ID] =~ m{^\d}
         and $message->[ID] > $self->{bytes_answered} );

--- a/lib/Tachikoma/Nodes/Tail.pm
+++ b/lib/Tachikoma/Nodes/Tail.pm
@@ -7,7 +7,7 @@
 #             wait_to_send, wait_to_close, wait_to_delete,
 #             wait_for_delete, wait_for_a_while
 #
-# $Id: Tail.pm 35592 2018-10-24 03:55:04Z chris $
+# $Id: Tail.pm 35604 2018-10-24 16:33:02Z chris $
 #
 
 package Tachikoma::Nodes::Tail;
@@ -205,15 +205,17 @@ sub fill {
     my $msg_unanswered = $self->{msg_unanswered};
     my $max_unanswered = $self->{max_unanswered};
     return $self->check_timers($message) if ( not length $message->[FROM] );
-    return $self->stderr( 'WARNING: unexpected response from ',
+    return $self->stderr( 'WARNING: unexpected message from ',
         $message->[FROM] )
         if (not $msg_unanswered
         and not $message->[TYPE] & TM_ERROR
         and not $message->[TYPE] & TM_EOF );
     return
         if ( not $max_unanswered
-        or $message->[TYPE] != ( TM_PERSIST | TM_RESPONSE )
-        or $message->[PAYLOAD] ne 'cancel' );
+        or $message->[TYPE] != ( TM_PERSIST | TM_RESPONSE ) );
+    return $self->stderr( 'WARNING: unexpected response from ',
+        $message->[FROM] )
+        if ( $message->[PAYLOAD] ne 'cancel' );
     $self->{bytes_answered} = $message->[ID]
         if ($message->[ID] =~ m{^\d}
         and $message->[ID] > $self->{bytes_answered} );

--- a/lib/Tachikoma/Nodes/Topic.pm
+++ b/lib/Tachikoma/Nodes/Topic.pm
@@ -162,7 +162,7 @@ sub fire {
         my %batch = ();
         for my $message ( @{ $self->{batch} } ) {
             my $i = 0;
-            if ( $message->[TO] ) {
+            if ( length $message->[TO] ) {
                 $i = $message->[TO];
             }
             elsif ( $message->[STREAM] ) {

--- a/lib/Tachikoma/Nodes/Topic.pm
+++ b/lib/Tachikoma/Nodes/Topic.pm
@@ -121,7 +121,7 @@ sub fill {
                 $self->{batch_size} > $Batch_Threshold
                     || $Tachikoma::Now - $message->[TIMESTAMP] > 1
                 ? 0
-                : undef
+                : $Online_Interval * 1000
             ) if ( $self->{timer_interval} );
         }
         elsif ( $message->[TYPE] & TM_PERSIST ) {

--- a/t/shell.t
+++ b/t/shell.t
@@ -188,10 +188,10 @@ is( $answer, "{foo'bar}\n", 'backslash escapes quotes' );
 
 #####################################################################
 
-$parse_tree = $shell->parse("send echo '\\\\'");
+$parse_tree = $shell->parse("send echo '\\t\\n'");
 $answer     = q();
 $shell->send_command($parse_tree);
-is( $answer, "{\\\\}\n", 'single quotes escape backslash' );
+is( $answer, "{\\t\\n}\n", 'single quotes escape backslash' );
 
 #####################################################################
 


### PR DESCRIPTION
- Escape backslashes in shell language so `print '\\\''` prints `\'`.
- Refine message routing (allow "0" in node names and to/from message fields).
- Split FileHandle->drain_buffer into drain_buffer_normal() and drain_buffer_edge().
- Fix timer in Topic->fill used to batch messages.