### PR TITLE
MFC

### DIFF
--- a/lib/Tachikoma/Config.pm
+++ b/lib/Tachikoma/Config.pm
@@ -120,7 +120,7 @@ sub include_conf {
     my $script_path = shift;
     my $package     = $script_path;
     return if ( not -f $script_path );
-    $package =~ s{[^\w\d]+}{_}g;
+    $package =~ s{\W+}{_}g;
     $package =~ s{^(\d)}{_$1};
     $FORBIDDEN{$script_path} = 1;
     my $fh;

--- a/lib/Tachikoma/Nodes/BufferProbeToGraphite.pm
+++ b/lib/Tachikoma/Nodes/BufferProbeToGraphite.pm
@@ -61,7 +61,7 @@ sub fill {
         my $hostname  = $buffer->{hostname}  or next;
         my $buff_name = $buffer->{buff_name} or next;
         $hostname  =~ s{[.].*}{};
-        $buff_name =~ s{[^\w\d]+}{_}g;
+        $buff_name =~ s{\W+}{_}g;
         for my $field (@FIELDS) {
             my $key = join q(.),
                 $prefix, $hostname, 'tachikoma',

--- a/lib/Tachikoma/Nodes/CGI.pm
+++ b/lib/Tachikoma/Nodes/CGI.pm
@@ -268,7 +268,7 @@ sub include_path {
     my $script_path = shift;
     my $counter     = $self->{include_counter};
     my $package     = $script_path;
-    $package =~ s{[^\w\d]+}{_}g;
+    $package =~ s{\W+}{_}g;
     $package =~ s{^(\d)}{_$1};
     $package .= join q(), q(_), $counter;
     $counter = ( $counter + 1 ) % $Tachikoma::Max_Int;

--- a/lib/Tachikoma/Nodes/CommandInterpreter.pm
+++ b/lib/Tachikoma/Nodes/CommandInterpreter.pm
@@ -279,7 +279,7 @@ sub topical_help {
     elsif ( $l->{$glob} ) {
         return $self->response( $envelope, join q(), @{ $l->{$glob} } );
     }
-    my $type = ( $glob =~ m{^([\w\d:]+)$} )[0];
+    my $type = ( $glob =~ m{^([\w:]+)$} )[0];
     if ($type) {
         my $class = undef;
         for my $prefix ( @{ $config->include_nodes }, 'Tachikoma::Nodes' ) {

--- a/lib/Tachikoma/Nodes/JobController.pm
+++ b/lib/Tachikoma/Nodes/JobController.pm
@@ -399,7 +399,7 @@ sub start_job {
     my $self    = shift;
     my $options = shift;
     die qq(no type specified\n) if ( not $options->{type} );
-    $options->{type} =~ s{[^\w\d:]}{}g;
+    $options->{type} =~ s{[^\w:]}{}g;
     $options->{name} ||= $options->{type};
     $options->{arguments} //= q();
     $options->{owner}     //= q();

--- a/lib/Tachikoma/Nodes/TopicProbeToGraphite.pm
+++ b/lib/Tachikoma/Nodes/TopicProbeToGraphite.pm
@@ -83,7 +83,7 @@ sub fire {
             my $topic    = $self->{consumers}->{$partition}->{$consumer};
             my $hostname = $topic->{hostname};
             $hostname =~ s{[.].*}{};
-            $consumer =~ s{[^\w\d]+}{_}g;
+            $consumer =~ s{\W+}{_}g;
             $topic->{p_offset} = $p_offset;
             $topic->{distance} = $p_offset - $topic->{c_offset};
             for my $field (@FIELDS) {

--- a/t/shell3.t
+++ b/t/shell3.t
@@ -84,7 +84,7 @@ is_deeply(
     {
         'commands' => [
             {
-                'name' => { 
+                'name' => {
                     'type' => 'ident',
                     'value' => 'foo'
                 },
@@ -92,7 +92,7 @@ is_deeply(
                 'value' => {
                     'type' => 'parenthesized_expr',
                     'expressions' => [
-                        { 
+                        {
                             'type' => 'number',
                             'value' => 5
                         }


### PR DESCRIPTION
This pull request updates several regular expressions used for string sanitization and parsing throughout the codebase. The main change is the replacement of `[^\w\d]+` with `\W+` in multiple places, which simplifies and standardizes how non-word characters are handled. Additionally, there are minor adjustments to type parsing to allow colons.

**Regular expression updates for string sanitization:**

* Replaced `[^\w\d]+` with `\W+` in the `include_conf` function in `lib/Tachikoma/Config.pm`, improving consistency in how script paths are sanitized for package names.
* Replaced `[^\w\d]+` with `\W+` in the `fill` function in `lib/Tachikoma/Nodes/BufferProbeToGraphite.pm`, standardizing buffer name sanitization.
* Replaced `[^\w\d]+` with `\W+` in the `include_path` function in `lib/Tachikoma/Nodes/CGI.pm`, ensuring consistent package name formatting from script paths.
* Replaced `[^\w\d]+` with `\W+` in the `fire` function in `lib/Tachikoma/Nodes/TopicProbeToGraphite.pm`, standardizing consumer name sanitization.

**Type parsing improvements:**

* Updated the regular expression in the `topical_help` function in `lib/Tachikoma/Nodes/CommandInterpreter.pm` to allow colons in the type match, changing from `([\w\d:]+)` to `([\w:]+)`.
* Modified the type sanitization in `start_job` in `lib/Tachikoma/Nodes/JobController.pm` to allow colons, changing from `[^\w\d:]` to `[^\w:]`.